### PR TITLE
Launch Firefox with -remote-allow-system-access for chrome-context fa…

### DIFF
--- a/COMMIT_HISTORY.md
+++ b/COMMIT_HISTORY.md
@@ -1,11 +1,49 @@
 # Git Commit History
 
-**Generated**: 2026-08-05T16:12:49.320Z
-**Total Commits**: 539
+**Generated**: 2026-08-05T16:14:25.767Z
+**Total Commits**: 541
 
 ---
 
-## Commit 1: chore: update commit history
+## Commit 1: Launch Firefox with -remote-allow-system-access for chrome-context fallback
+
+**Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
+**Date**: 2026-08-05 21:43:33 +0530
+**Commit Hash**: `795b780701ed33bec1c2a9cfbfa3914f4d368780`
+**Short Hash**: `795b780`
+
+### Files Modified
+
+- **Modified**: `tests/ci-runner.js`
+
+### Commit Message
+
+```text
+Launch Firefox with -remote-allow-system-access for chrome-context fallback
+```
+
+---
+
+## Commit 2: chore: update commit history
+
+**Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+**Date**: 2026-08-05 16:12:49 +0000
+**Commit Hash**: `305ce246c683da6aee2dbb5e64dbcfbba5a35c36`
+**Short Hash**: `305ce24`
+
+### Files Modified
+
+- **Modified**: `COMMIT_HISTORY.md`
+
+### Commit Message
+
+```text
+chore: update commit history
+```
+
+---
+
+## Commit 3: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-08-05 16:12:12 +0000
@@ -24,7 +62,7 @@ chore: update commit history
 
 ---
 
-## Commit 2: Fix regression runner navigation to extension pages
+## Commit 4: Fix regression runner navigation to extension pages
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-08-05 21:39:53 +0530
@@ -43,7 +81,7 @@ Fix regression runner navigation to extension pages
 
 ---
 
-## Commit 3: Fix parser and storage bugs in clearurls, IP-Ranger, and storage
+## Commit 5: Fix parser and storage bugs in clearurls, IP-Ranger, and storage
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-08-05 21:39:45 +0530
@@ -64,7 +102,7 @@ Fix parser and storage bugs in clearurls, IP-Ranger, and storage
 
 ---
 
-## Commit 4: chore: update commit history
+## Commit 6: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-08-04 20:25:48 +0000
@@ -83,7 +121,7 @@ chore: update commit history
 
 ---
 
-## Commit 5: chore: update commit history
+## Commit 7: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-08-04 20:22:27 +0000
@@ -102,7 +140,7 @@ chore: update commit history
 
 ---
 
-## Commit 6: Migrate GitHub Actions workflows to Node 24 runtime
+## Commit 8: Migrate GitHub Actions workflows to Node 24 runtime
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-08-05 01:52:04 +0530
@@ -123,7 +161,7 @@ Migrate GitHub Actions workflows to Node 24 runtime
 
 ---
 
-## Commit 7: chore: update commit history
+## Commit 9: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-08-04 20:18:52 +0000
@@ -142,7 +180,7 @@ chore: update commit history
 
 ---
 
-## Commit 8: Update regression-test.yml
+## Commit 10: Update regression-test.yml
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-08-05 01:48:30 +0530
@@ -161,7 +199,7 @@ Update regression-test.yml
 
 ---
 
-## Commit 9: chore: update commit history
+## Commit 11: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-08-04 20:16:32 +0000
@@ -180,7 +218,7 @@ chore: update commit history
 
 ---
 
-## Commit 10: Update regression-test.yml
+## Commit 12: Update regression-test.yml
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-08-05 01:46:16 +0530
@@ -199,7 +237,7 @@ Update regression-test.yml
 
 ---
 
-## Commit 11: chore: update changelog for v100.38.0
+## Commit 13: chore: update changelog for v100.38.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-08-04 20:10:30 +0000
@@ -218,7 +256,7 @@ chore: update changelog for v100.38.0
 
 ---
 
-## Commit 12: chore: update commit history for v100.38.0
+## Commit 14: chore: update commit history for v100.38.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-08-04 20:10:28 +0000
@@ -237,7 +275,7 @@ chore: update commit history for v100.38.0
 
 ---
 
-## Commit 13: release 100.38.0
+## Commit 15: release 100.38.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-08-04 20:10:27 +0000
@@ -258,7 +296,7 @@ release 100.38.0
 
 ---
 
-## Commit 14: chore: update commit history
+## Commit 16: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-08-04 20:05:33 +0000
@@ -277,7 +315,7 @@ chore: update commit history
 
 ---
 
-## Commit 15: chore: update commit history
+## Commit 17: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-08-04 20:02:30 +0000
@@ -296,7 +334,7 @@ chore: update commit history
 
 ---
 
-## Commit 16: Support IPv4/IPv6 addresses in the whitelist
+## Commit 18: Support IPv4/IPv6 addresses in the whitelist
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-08-05 01:31:37 +0530
@@ -324,7 +362,7 @@ Support IPv4/IPv6 addresses in the whitelist
 
 ---
 
-## Commit 17: chore: update changelog for v100.37.0
+## Commit 19: chore: update changelog for v100.37.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-08-02 02:32:46 +0000
@@ -343,7 +381,7 @@ chore: update changelog for v100.37.0
 
 ---
 
-## Commit 18: chore: update commit history for v100.37.0
+## Commit 20: chore: update commit history for v100.37.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-08-02 02:32:45 +0000
@@ -362,7 +400,7 @@ chore: update commit history for v100.37.0
 
 ---
 
-## Commit 19: release 100.37.0
+## Commit 21: release 100.37.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-08-02 02:32:44 +0000
@@ -384,7 +422,7 @@ release 100.37.0
 
 ---
 
-## Commit 20: chore: update changelog for v100.36.1
+## Commit 22: chore: update changelog for v100.36.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-26 12:41:17 +0000
@@ -403,7 +441,7 @@ chore: update changelog for v100.36.1
 
 ---
 
-## Commit 21: chore: update commit history for v100.36.1
+## Commit 23: chore: update commit history for v100.36.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-26 12:41:16 +0000
@@ -422,7 +460,7 @@ chore: update commit history for v100.36.1
 
 ---
 
-## Commit 22: release 100.36.1
+## Commit 24: release 100.36.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-26 12:41:15 +0000
@@ -443,7 +481,7 @@ release 100.36.1
 
 ---
 
-## Commit 23: chore: update commit history
+## Commit 25: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-26 12:33:09 +0000
@@ -462,7 +500,7 @@ chore: update commit history
 
 ---
 
-## Commit 24: Fix WCAG 2.1 AA gaps across extension UI
+## Commit 26: Fix WCAG 2.1 AA gaps across extension UI
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-07-26 18:02:11 +0530
@@ -496,7 +534,7 @@ Fix WCAG 2.1 AA gaps across extension UI
 
 ---
 
-## Commit 25: chore: update changelog for v100.36.0
+## Commit 27: chore: update changelog for v100.36.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-26 02:33:16 +0000
@@ -515,7 +553,7 @@ chore: update changelog for v100.36.0
 
 ---
 
-## Commit 26: chore: update commit history for v100.36.0
+## Commit 28: chore: update commit history for v100.36.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-26 02:33:15 +0000
@@ -534,7 +572,7 @@ chore: update commit history for v100.36.0
 
 ---
 
-## Commit 27: release 100.36.0
+## Commit 29: release 100.36.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-26 02:33:14 +0000
@@ -556,7 +594,7 @@ release 100.36.0
 
 ---
 
-## Commit 28: chore: update changelog for v100.35.0
+## Commit 30: chore: update changelog for v100.35.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-19 02:29:02 +0000
@@ -575,7 +613,7 @@ chore: update changelog for v100.35.0
 
 ---
 
-## Commit 29: chore: update commit history for v100.35.0
+## Commit 31: chore: update commit history for v100.35.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-19 02:29:00 +0000
@@ -594,7 +632,7 @@ chore: update commit history for v100.35.0
 
 ---
 
-## Commit 30: release 100.35.0
+## Commit 32: release 100.35.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-19 02:28:59 +0000
@@ -616,7 +654,7 @@ release 100.35.0
 
 ---
 
-## Commit 31: chore: update changelog for v100.34.0
+## Commit 33: chore: update changelog for v100.34.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-12 13:02:42 +0000
@@ -635,7 +673,7 @@ chore: update changelog for v100.34.0
 
 ---
 
-## Commit 32: chore: update commit history for v100.34.0
+## Commit 34: chore: update commit history for v100.34.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-12 13:02:40 +0000
@@ -654,7 +692,7 @@ chore: update commit history for v100.34.0
 
 ---
 
-## Commit 33: release 100.34.0
+## Commit 35: release 100.34.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-12 13:02:39 +0000
@@ -675,7 +713,7 @@ release 100.34.0
 
 ---
 
-## Commit 34: chore: update commit history
+## Commit 36: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-12 13:01:34 +0000
@@ -694,7 +732,7 @@ chore: update commit history
 
 ---
 
-## Commit 35: Add Samarth ref removeparam exception
+## Commit 37: Add Samarth ref removeparam exception
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-07-12 18:30:55 +0530
@@ -713,7 +751,7 @@ Add Samarth ref removeparam exception
 
 ---
 
-## Commit 36: chore: update changelog for v100.33.0
+## Commit 38: chore: update changelog for v100.33.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-12 02:32:03 +0000
@@ -732,7 +770,7 @@ chore: update changelog for v100.33.0
 
 ---
 
-## Commit 37: chore: update commit history for v100.33.0
+## Commit 39: chore: update commit history for v100.33.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-12 02:32:02 +0000
@@ -751,7 +789,7 @@ chore: update commit history for v100.33.0
 
 ---
 
-## Commit 38: release 100.33.0
+## Commit 40: release 100.33.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-12 02:32:01 +0000
@@ -773,7 +811,7 @@ release 100.33.0
 
 ---
 
-## Commit 39: chore: update changelog for v100.32.0
+## Commit 41: chore: update changelog for v100.32.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-05 02:51:37 +0000
@@ -792,7 +830,7 @@ chore: update changelog for v100.32.0
 
 ---
 
-## Commit 40: chore: update commit history for v100.32.0
+## Commit 42: chore: update commit history for v100.32.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-05 02:51:36 +0000
@@ -811,7 +849,7 @@ chore: update commit history for v100.32.0
 
 ---
 
-## Commit 41: release 100.32.0
+## Commit 43: release 100.32.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-05 02:51:35 +0000
@@ -833,7 +871,7 @@ release 100.32.0
 
 ---
 
-## Commit 42: chore: update changelog for v100.31.0
+## Commit 44: chore: update changelog for v100.31.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-01 19:00:08 +0000
@@ -852,7 +890,7 @@ chore: update changelog for v100.31.0
 
 ---
 
-## Commit 43: chore: update commit history for v100.31.0
+## Commit 45: chore: update commit history for v100.31.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-01 19:00:07 +0000
@@ -871,7 +909,7 @@ chore: update commit history for v100.31.0
 
 ---
 
-## Commit 44: release 100.31.0
+## Commit 46: release 100.31.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-07-01 19:00:05 +0000
@@ -893,7 +931,7 @@ release 100.31.0
 
 ---
 
-## Commit 45: chore: update commit history
+## Commit 47: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-29 15:11:34 +0000
@@ -912,7 +950,7 @@ chore: update commit history
 
 ---
 
-## Commit 46: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
+## Commit 48: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-29 20:41:16 +0530
@@ -931,7 +969,7 @@ Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 ---
 
-## Commit 47: wcag complaince we donot know how much we done i think we complaint with wcag with good faith
+## Commit 49: wcag complaince we donot know how much we done i think we complaint with wcag with good faith
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-29 20:40:25 +0530
@@ -969,7 +1007,7 @@ wcag complaince we donot know how much we done i think we complaint with wcag wi
 
 ---
 
-## Commit 48: chore: update changelog for v100.30.0
+## Commit 50: chore: update changelog for v100.30.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-28 03:35:29 +0000
@@ -988,7 +1026,7 @@ chore: update changelog for v100.30.0
 
 ---
 
-## Commit 49: chore: update commit history for v100.30.0
+## Commit 51: chore: update commit history for v100.30.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-28 03:35:28 +0000
@@ -1007,7 +1045,7 @@ chore: update commit history for v100.30.0
 
 ---
 
-## Commit 50: release 100.30.0
+## Commit 52: release 100.30.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-28 03:35:27 +0000
@@ -1029,7 +1067,7 @@ release 100.30.0
 
 ---
 
-## Commit 51: chore: update changelog for v100.29.0
+## Commit 53: chore: update changelog for v100.29.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-21 03:58:23 +0000
@@ -1048,7 +1086,7 @@ chore: update changelog for v100.29.0
 
 ---
 
-## Commit 52: chore: update commit history for v100.29.0
+## Commit 54: chore: update commit history for v100.29.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-21 03:58:22 +0000
@@ -1067,7 +1105,7 @@ chore: update commit history for v100.29.0
 
 ---
 
-## Commit 53: release 100.29.0
+## Commit 55: release 100.29.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-21 03:58:21 +0000
@@ -1088,7 +1126,7 @@ release 100.29.0
 
 ---
 
-## Commit 54: chore: update changelog for v100.28.1
+## Commit 56: chore: update changelog for v100.28.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-20 20:56:33 +0000
@@ -1107,7 +1145,7 @@ chore: update changelog for v100.28.1
 
 ---
 
-## Commit 55: chore: update commit history for v100.28.1
+## Commit 57: chore: update commit history for v100.28.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-20 20:56:32 +0000
@@ -1126,7 +1164,7 @@ chore: update commit history for v100.28.1
 
 ---
 
-## Commit 56: release 100.28.1
+## Commit 58: release 100.28.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-20 20:56:31 +0000
@@ -1147,7 +1185,7 @@ release 100.28.1
 
 ---
 
-## Commit 57: chore: update commit history
+## Commit 59: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-20 17:58:51 +0000
@@ -1166,7 +1204,7 @@ chore: update commit history
 
 ---
 
-## Commit 58: added withdrawn button
+## Commit 60: added withdrawn button
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-20 23:28:16 +0530
@@ -1241,7 +1279,7 @@ added withdrawn button
 
 ---
 
-## Commit 59: chore: update changelog for v100.28.0
+## Commit 61: chore: update changelog for v100.28.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-16 19:01:43 +0000
@@ -1260,7 +1298,7 @@ chore: update changelog for v100.28.0
 
 ---
 
-## Commit 60: chore: update commit history for v100.28.0
+## Commit 62: chore: update commit history for v100.28.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-16 19:01:41 +0000
@@ -1279,7 +1317,7 @@ chore: update commit history for v100.28.0
 
 ---
 
-## Commit 61: release 100.28.0
+## Commit 63: release 100.28.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-16 19:01:40 +0000
@@ -1300,7 +1338,7 @@ release 100.28.0
 
 ---
 
-## Commit 62: chore: update commit history
+## Commit 64: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-16 17:35:12 +0000
@@ -1319,7 +1357,7 @@ chore: update commit history
 
 ---
 
-## Commit 63: Although we do not collect any personal data from users, there has been increasing pressure in recent years from various groups advocating for broader age-verification and surveillance measures. To address these concerns while preserving user privacy, we have adopted the following approach.
+## Commit 65: Although we do not collect any personal data from users, there has been increasing pressure in recent years from various groups advocating for broader age-verification and surveillance measures. To address these concerns while preserving user privacy, we have adopted the following approach.
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-16 23:03:33 +0530
@@ -1400,7 +1438,7 @@ Although we do not collect any personal data from users, there has been increasi
 
 ---
 
-## Commit 64: chore: update commit history
+## Commit 66: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-16 11:09:38 +0000
@@ -1419,7 +1457,7 @@ chore: update commit history
 
 ---
 
-## Commit 65: Refine Thai guide translation
+## Commit 67: Refine Thai guide translation
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-16 16:39:03 +0530
@@ -1438,7 +1476,7 @@ Refine Thai guide translation
 
 ---
 
-## Commit 66: chore: update changelog for v100.27.0
+## Commit 68: chore: update changelog for v100.27.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-16 11:07:16 +0000
@@ -1457,7 +1495,7 @@ chore: update changelog for v100.27.0
 
 ---
 
-## Commit 67: chore: update commit history for v100.27.0
+## Commit 69: chore: update commit history for v100.27.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-16 11:07:14 +0000
@@ -1476,7 +1514,7 @@ chore: update commit history for v100.27.0
 
 ---
 
-## Commit 68: release 100.27.0
+## Commit 70: release 100.27.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-16 11:07:13 +0000
@@ -1498,7 +1536,7 @@ release 100.27.0
 
 ---
 
-## Commit 69: chore: update commit history
+## Commit 71: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-16 11:05:42 +0000
@@ -1517,7 +1555,7 @@ chore: update commit history
 
 ---
 
-## Commit 70: Update privacy notices and rules guide
+## Commit 72: Update privacy notices and rules guide
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-16 16:34:53 +0530
@@ -1596,7 +1634,7 @@ Update privacy notices and rules guide
 
 ---
 
-## Commit 71: Add chained legal consent review modal
+## Commit 73: Add chained legal consent review modal
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-16 14:44:30 +0530
@@ -1671,7 +1709,7 @@ Add chained legal consent review modal
 
 ---
 
-## Commit 72: chore: update changelog for v100.26.0
+## Commit 74: chore: update changelog for v100.26.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-14 03:51:05 +0000
@@ -1690,7 +1728,7 @@ chore: update changelog for v100.26.0
 
 ---
 
-## Commit 73: chore: update commit history for v100.26.0
+## Commit 75: chore: update commit history for v100.26.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-14 03:51:04 +0000
@@ -1709,7 +1747,7 @@ chore: update commit history for v100.26.0
 
 ---
 
-## Commit 74: release 100.26.0
+## Commit 76: release 100.26.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-14 03:51:03 +0000
@@ -1730,7 +1768,7 @@ release 100.26.0
 
 ---
 
-## Commit 75: chore: update changelog for v100.25.0
+## Commit 77: chore: update changelog for v100.25.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-13 18:38:18 +0000
@@ -1749,7 +1787,7 @@ chore: update changelog for v100.25.0
 
 ---
 
-## Commit 76: chore: update commit history for v100.25.0
+## Commit 78: chore: update commit history for v100.25.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-13 18:38:17 +0000
@@ -1768,7 +1806,7 @@ chore: update commit history for v100.25.0
 
 ---
 
-## Commit 77: release 100.25.0
+## Commit 79: release 100.25.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-13 18:38:16 +0000
@@ -1789,7 +1827,7 @@ release 100.25.0
 
 ---
 
-## Commit 78: chore: update commit history
+## Commit 80: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-13 17:35:03 +0000
@@ -1808,7 +1846,7 @@ chore: update commit history
 
 ---
 
-## Commit 79: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
+## Commit 81: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-13 23:04:48 +0530
@@ -1827,7 +1865,7 @@ Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 ---
 
-## Commit 80: updated privacy policy
+## Commit 82: updated privacy policy
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-13 23:04:21 +0530
@@ -1847,7 +1885,7 @@ updated privacy policy
 
 ---
 
-## Commit 81: chore: update commit history
+## Commit 83: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-13 10:17:45 +0000
@@ -1866,7 +1904,7 @@ chore: update commit history
 
 ---
 
-## Commit 82: Add POSAR consent flow and translations
+## Commit 84: Add POSAR consent flow and translations
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-13 15:46:57 +0530
@@ -1944,7 +1982,7 @@ Add POSAR consent flow and translations
 
 ---
 
-## Commit 83: chore: update commit history
+## Commit 85: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-12 11:15:03 +0000
@@ -1963,7 +2001,7 @@ chore: update commit history
 
 ---
 
-## Commit 84: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
+## Commit 86: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-12 16:44:46 +0530
@@ -1982,7 +2020,7 @@ Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 ---
 
-## Commit 85: updated
+## Commit 87: updated
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-12 16:44:33 +0530
@@ -2001,7 +2039,7 @@ updated
 
 ---
 
-## Commit 86: chore: update commit history
+## Commit 88: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-12 11:00:35 +0000
@@ -2020,7 +2058,7 @@ chore: update commit history
 
 ---
 
-## Commit 87: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
+## Commit 89: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-12 16:30:20 +0530
@@ -2039,7 +2077,7 @@ Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 ---
 
-## Commit 88: new policy
+## Commit 90: new policy
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-12 16:30:00 +0530
@@ -2058,7 +2096,7 @@ new policy
 
 ---
 
-## Commit 89: chore: update changelog for v100.24.0
+## Commit 91: chore: update changelog for v100.24.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-12 10:49:32 +0000
@@ -2077,7 +2115,7 @@ chore: update changelog for v100.24.0
 
 ---
 
-## Commit 90: chore: update commit history for v100.24.0
+## Commit 92: chore: update commit history for v100.24.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-12 10:49:31 +0000
@@ -2096,7 +2134,7 @@ chore: update commit history for v100.24.0
 
 ---
 
-## Commit 91: release 100.24.0
+## Commit 93: release 100.24.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-12 10:49:30 +0000
@@ -2117,7 +2155,7 @@ release 100.24.0
 
 ---
 
-## Commit 92: chore: update changelog for v100.23.0
+## Commit 94: chore: update changelog for v100.23.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-11 12:18:03 +0000
@@ -2136,7 +2174,7 @@ chore: update changelog for v100.23.0
 
 ---
 
-## Commit 93: chore: update commit history for v100.23.0
+## Commit 95: chore: update commit history for v100.23.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-11 12:18:02 +0000
@@ -2155,7 +2193,7 @@ chore: update commit history for v100.23.0
 
 ---
 
-## Commit 94: release 100.23.0
+## Commit 96: release 100.23.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-11 12:18:01 +0000
@@ -2176,7 +2214,7 @@ release 100.23.0
 
 ---
 
-## Commit 95: chore: update changelog for v100.22.0
+## Commit 97: chore: update changelog for v100.22.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-11 07:46:05 +0000
@@ -2195,7 +2233,7 @@ chore: update changelog for v100.22.0
 
 ---
 
-## Commit 96: chore: update commit history for v100.22.0
+## Commit 98: chore: update commit history for v100.22.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-11 07:46:03 +0000
@@ -2214,7 +2252,7 @@ chore: update commit history for v100.22.0
 
 ---
 
-## Commit 97: release 100.22.0
+## Commit 99: release 100.22.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-11 07:46:02 +0000
@@ -2237,7 +2275,7 @@ release 100.22.0
 
 ---
 
-## Commit 98: chore: update commit history
+## Commit 100: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-10 13:29:37 +0000
@@ -2256,7 +2294,7 @@ chore: update commit history
 
 ---
 
-## Commit 99: Replace logger controls with SVG icons
+## Commit 101: Replace logger controls with SVG icons
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-10 18:59:14 +0530
@@ -2279,7 +2317,7 @@ Replace logger controls with SVG icons
 
 ---
 
-## Commit 100: chore: update changelog for v100.21.2
+## Commit 102: chore: update changelog for v100.21.2
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-10 10:29:50 +0000
@@ -2298,7 +2336,7 @@ chore: update changelog for v100.21.2
 
 ---
 
-## Commit 101: chore: update commit history for v100.21.2
+## Commit 103: chore: update commit history for v100.21.2
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-10 10:29:49 +0000
@@ -2317,7 +2355,7 @@ chore: update commit history for v100.21.2
 
 ---
 
-## Commit 102: release 100.21.2
+## Commit 104: release 100.21.2
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-10 10:29:48 +0000
@@ -2339,7 +2377,7 @@ release 100.21.2
 
 ---
 
-## Commit 103: chore: update commit history
+## Commit 105: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-10 09:49:30 +0000
@@ -2358,7 +2396,7 @@ chore: update commit history
 
 ---
 
-## Commit 104: chore: update commit history
+## Commit 106: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-10 09:46:40 +0000
@@ -2377,7 +2415,7 @@ chore: update commit history
 
 ---
 
-## Commit 105: every things is anicca hope so there is no need this type of software to exist
+## Commit 107: every things is anicca hope so there is no need this type of software to exist
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-10 15:15:45 +0530
@@ -2396,7 +2434,7 @@ every things is anicca hope so there is no need this type of software to exist
 
 ---
 
-## Commit 106: chore: update changelog for v100.21.1
+## Commit 108: chore: update changelog for v100.21.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-09 05:09:06 +0000
@@ -2415,7 +2453,7 @@ chore: update changelog for v100.21.1
 
 ---
 
-## Commit 107: chore: update commit history for v100.21.1
+## Commit 109: chore: update commit history for v100.21.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-09 05:09:05 +0000
@@ -2434,7 +2472,7 @@ chore: update commit history for v100.21.1
 
 ---
 
-## Commit 108: release 100.21.1
+## Commit 110: release 100.21.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-09 05:09:04 +0000
@@ -2455,7 +2493,7 @@ release 100.21.1
 
 ---
 
-## Commit 109: chore: update commit history
+## Commit 111: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-08 19:50:47 +0000
@@ -2474,7 +2512,7 @@ chore: update commit history
 
 ---
 
-## Commit 110: update privacy policy
+## Commit 112: update privacy policy
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-09 01:17:24 +0530
@@ -2494,7 +2532,7 @@ update privacy policy
 
 ---
 
-## Commit 111: chore: update changelog for v100.21.0
+## Commit 113: chore: update changelog for v100.21.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-07 03:40:30 +0000
@@ -2513,7 +2551,7 @@ chore: update changelog for v100.21.0
 
 ---
 
-## Commit 112: chore: update commit history for v100.21.0
+## Commit 114: chore: update commit history for v100.21.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-07 03:40:29 +0000
@@ -2532,7 +2570,7 @@ chore: update commit history for v100.21.0
 
 ---
 
-## Commit 113: release 100.21.0
+## Commit 115: release 100.21.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-07 03:40:28 +0000
@@ -2553,7 +2591,7 @@ release 100.21.0
 
 ---
 
-## Commit 114: chore: update changelog for v100.20.2
+## Commit 116: chore: update changelog for v100.20.2
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-03 16:55:13 +0000
@@ -2572,7 +2610,7 @@ chore: update changelog for v100.20.2
 
 ---
 
-## Commit 115: chore: update commit history for v100.20.2
+## Commit 117: chore: update commit history for v100.20.2
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-03 16:55:12 +0000
@@ -2591,7 +2629,7 @@ chore: update commit history for v100.20.2
 
 ---
 
-## Commit 116: release 100.20.2
+## Commit 118: release 100.20.2
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-03 16:55:10 +0000
@@ -2613,7 +2651,7 @@ release 100.20.2
 
 ---
 
-## Commit 117: chore: update commit history
+## Commit 119: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-03 16:53:01 +0000
@@ -2632,7 +2670,7 @@ chore: update commit history
 
 ---
 
-## Commit 118: updated template
+## Commit 120: updated template
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-03 22:22:19 +0530
@@ -2651,7 +2689,7 @@ updated template
 
 ---
 
-## Commit 119: chore: update commit history
+## Commit 121: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-02 15:59:36 +0000
@@ -2670,7 +2708,7 @@ chore: update commit history
 
 ---
 
-## Commit 120: Remove legacy interoperability runtime traces
+## Commit 122: Remove legacy interoperability runtime traces
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-02 21:28:47 +0530
@@ -2750,7 +2788,7 @@ Remove legacy interoperability runtime traces
 
 ---
 
-## Commit 121: chore: update commit history
+## Commit 123: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-02 15:48:45 +0000
@@ -2769,7 +2807,7 @@ chore: update commit history
 
 ---
 
-## Commit 122: Remove legacy interoperability runtime docs
+## Commit 124: Remove legacy interoperability runtime docs
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-02 21:18:14 +0530
@@ -2850,7 +2888,7 @@ Remove legacy interoperability runtime docs
 
 ---
 
-## Commit 123: chore: update commit history
+## Commit 125: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-02 15:24:25 +0000
@@ -2869,7 +2907,7 @@ chore: update commit history
 
 ---
 
-## Commit 124: Remove unused filtering context runtime
+## Commit 126: Remove unused filtering context runtime
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-02 20:53:48 +0530
@@ -2889,7 +2927,7 @@ Remove unused filtering context runtime
 
 ---
 
-## Commit 125: chore: update commit history
+## Commit 127: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-02 10:58:33 +0000
@@ -2908,7 +2946,7 @@ chore: update commit history
 
 ---
 
-## Commit 126: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
+## Commit 128: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-02 16:28:19 +0530
@@ -2927,7 +2965,7 @@ Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 ---
 
-## Commit 127: Remove unsupported removeparam modifiers
+## Commit 129: Remove unsupported removeparam modifiers
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-02 16:28:14 +0530
@@ -2946,7 +2984,7 @@ Remove unsupported removeparam modifiers
 
 ---
 
-## Commit 128: chore: update commit history
+## Commit 130: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-02 10:31:16 +0000
@@ -2965,7 +3003,7 @@ chore: update commit history
 
 ---
 
-## Commit 129: Remove removeparam app modifier
+## Commit 131: Remove removeparam app modifier
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-02 16:00:56 +0530
@@ -2986,7 +3024,7 @@ Remove removeparam app modifier
 
 ---
 
-## Commit 130: chore: update commit history
+## Commit 132: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-01 19:13:59 +0000
@@ -3005,7 +3043,7 @@ chore: update commit history
 
 ---
 
-## Commit 131: Retire url filter runtime
+## Commit 133: Retire url filter runtime
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-02 00:43:06 +0530
@@ -3041,7 +3079,7 @@ Retire url filter runtime
 
 ---
 
-## Commit 132: chore: update commit history
+## Commit 134: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-01 18:34:55 +0000
@@ -3060,7 +3098,7 @@ chore: update commit history
 
 ---
 
-## Commit 133: Fix ClearURLs removeparam modifiers
+## Commit 135: Fix ClearURLs removeparam modifiers
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-02 00:04:26 +0530
@@ -3082,7 +3120,7 @@ Fix ClearURLs removeparam modifiers
 
 ---
 
-## Commit 134: chore: update changelog for v100.20.1
+## Commit 136: chore: update changelog for v100.20.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-01 15:30:55 +0000
@@ -3101,7 +3139,7 @@ chore: update changelog for v100.20.1
 
 ---
 
-## Commit 135: chore: update commit history for v100.20.1
+## Commit 137: chore: update commit history for v100.20.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-01 15:30:54 +0000
@@ -3120,7 +3158,7 @@ chore: update commit history for v100.20.1
 
 ---
 
-## Commit 136: release 100.20.1
+## Commit 138: release 100.20.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-01 15:30:52 +0000
@@ -3141,7 +3179,7 @@ release 100.20.1
 
 ---
 
-## Commit 137: chore: update commit history
+## Commit 139: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-06-01 15:28:28 +0000
@@ -3160,7 +3198,7 @@ chore: update commit history
 
 ---
 
-## Commit 138: Add configurable report sharing
+## Commit 140: Add configurable report sharing
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-06-01 20:57:54 +0530
@@ -3235,7 +3273,7 @@ Add configurable report sharing
 
 ---
 
-## Commit 139: chore: update changelog for v100.20.0
+## Commit 141: chore: update changelog for v100.20.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-31 03:36:47 +0000
@@ -3254,7 +3292,7 @@ chore: update changelog for v100.20.0
 
 ---
 
-## Commit 140: chore: update commit history for v100.20.0
+## Commit 142: chore: update commit history for v100.20.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-31 03:36:46 +0000
@@ -3273,7 +3311,7 @@ chore: update commit history for v100.20.0
 
 ---
 
-## Commit 141: release 100.20.0
+## Commit 143: release 100.20.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-31 03:36:45 +0000
@@ -3294,7 +3332,7 @@ release 100.20.0
 
 ---
 
-## Commit 142: chore: update commit history
+## Commit 144: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-30 16:03:26 +0000
@@ -3313,7 +3351,7 @@ chore: update commit history
 
 ---
 
-## Commit 143: Fix custom provider count calculation
+## Commit 145: Fix custom provider count calculation
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-30 21:32:36 +0530
@@ -3334,7 +3372,7 @@ Fix custom provider count calculation
 
 ---
 
-## Commit 144: chore: update changelog for v100.19.0
+## Commit 146: chore: update changelog for v100.19.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-30 12:04:37 +0000
@@ -3353,7 +3391,7 @@ chore: update changelog for v100.19.0
 
 ---
 
-## Commit 145: chore: update commit history for v100.19.0
+## Commit 147: chore: update commit history for v100.19.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-30 12:04:36 +0000
@@ -3372,7 +3410,7 @@ chore: update commit history for v100.19.0
 
 ---
 
-## Commit 146: release 100.19.0
+## Commit 148: release 100.19.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-30 12:04:35 +0000
@@ -3395,7 +3433,7 @@ release 100.19.0
 
 ---
 
-## Commit 147: chore: update commit history
+## Commit 149: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-30 11:48:55 +0000
@@ -3414,7 +3452,7 @@ chore: update commit history
 
 ---
 
-## Commit 148: added guidebook completly fully
+## Commit 150: added guidebook completly fully
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-30 17:18:06 +0530
@@ -3489,7 +3527,7 @@ added guidebook completly fully
 
 ---
 
-## Commit 149: chore: update commit history
+## Commit 151: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-30 10:52:18 +0000
@@ -3508,7 +3546,7 @@ chore: update commit history
 
 ---
 
-## Commit 150: updated translations and update guide.html and guide.js
+## Commit 152: updated translations and update guide.html and guide.js
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-30 16:21:18 +0530
@@ -3584,7 +3622,7 @@ updated translations and update guide.html and guide.js
 
 ---
 
-## Commit 151: chore: update commit history
+## Commit 153: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-29 17:44:56 +0000
@@ -3603,7 +3641,7 @@ chore: update commit history
 
 ---
 
-## Commit 152: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
+## Commit 154: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-29 23:14:40 +0530
@@ -3622,7 +3660,7 @@ Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 ---
 
-## Commit 153: added guide
+## Commit 155: added guide
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-29 23:14:23 +0530
@@ -3642,7 +3680,7 @@ added guide
 
 ---
 
-## Commit 154: deleted file we replaced with html
+## Commit 156: deleted file we replaced with html
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-29 22:33:42 +0530
@@ -3662,7 +3700,7 @@ deleted file we replaced with html
 
 ---
 
-## Commit 155: chore: update commit history
+## Commit 157: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-29 16:47:37 +0000
@@ -3681,7 +3719,7 @@ chore: update commit history
 
 ---
 
-## Commit 156: add proper syntax docs
+## Commit 158: add proper syntax docs
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-29 22:16:09 +0530
@@ -3701,7 +3739,7 @@ add proper syntax docs
 
 ---
 
-## Commit 157: chore: update changelog for v100.18.0
+## Commit 159: chore: update changelog for v100.18.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-28 20:01:18 +0000
@@ -3720,7 +3758,7 @@ chore: update changelog for v100.18.0
 
 ---
 
-## Commit 158: chore: update commit history for v100.18.0
+## Commit 160: chore: update commit history for v100.18.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-28 20:01:17 +0000
@@ -3739,7 +3777,7 @@ chore: update commit history for v100.18.0
 
 ---
 
-## Commit 159: release 100.18.0
+## Commit 161: release 100.18.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-28 20:01:16 +0000
@@ -3760,7 +3798,7 @@ release 100.18.0
 
 ---
 
-## Commit 160: chore: update commit history
+## Commit 162: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-28 15:51:40 +0000
@@ -3779,7 +3817,7 @@ chore: update commit history
 
 ---
 
-## Commit 161: adopted more syntax removeparam for clearurls.js
+## Commit 163: adopted more syntax removeparam for clearurls.js
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-28 21:20:39 +0530
@@ -3807,7 +3845,7 @@ adopted more syntax removeparam for clearurls.js
 
 ---
 
-## Commit 162: chore: update commit history
+## Commit 164: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-28 14:23:54 +0000
@@ -3826,7 +3864,7 @@ chore: update commit history
 
 ---
 
-## Commit 163: Use pattern-scoped rule disable IDs
+## Commit 165: Use pattern-scoped rule disable IDs
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-28 19:53:32 +0530
@@ -3847,7 +3885,7 @@ Use pattern-scoped rule disable IDs
 
 ---
 
-## Commit 164: chore: update changelog for v100.17.1
+## Commit 166: chore: update changelog for v100.17.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-28 09:14:57 +0000
@@ -3866,7 +3904,7 @@ chore: update changelog for v100.17.1
 
 ---
 
-## Commit 165: chore: update commit history for v100.17.1
+## Commit 167: chore: update commit history for v100.17.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-28 09:14:56 +0000
@@ -3885,7 +3923,7 @@ chore: update commit history for v100.17.1
 
 ---
 
-## Commit 166: release 100.17.1
+## Commit 168: release 100.17.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-28 09:14:55 +0000
@@ -3907,7 +3945,7 @@ release 100.17.1
 
 ---
 
-## Commit 167: chore: update commit history
+## Commit 169: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-27 17:21:20 +0000
@@ -3926,7 +3964,7 @@ chore: update commit history
 
 ---
 
-## Commit 168: Migrate ClearURLs rules to canonical Linkumori source
+## Commit 170: Migrate ClearURLs rules to canonical Linkumori source
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-27 22:43:11 +0530
@@ -3969,7 +4007,7 @@ Migrate ClearURLs rules to canonical Linkumori source
 
 ---
 
-## Commit 169: chore: update commit history
+## Commit 171: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-27 07:13:59 +0000
@@ -3988,7 +4026,7 @@ chore: update commit history
 
 ---
 
-## Commit 170: Allow regression page to read imported suite
+## Commit 172: Allow regression page to read imported suite
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-27 12:43:44 +0530
@@ -4007,7 +4045,7 @@ Allow regression page to read imported suite
 
 ---
 
-## Commit 171: chore: update commit history
+## Commit 173: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-27 07:11:41 +0000
@@ -4026,7 +4064,7 @@ chore: update commit history
 
 ---
 
-## Commit 172: Fix settings regression suite import
+## Commit 174: Fix settings regression suite import
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-27 12:41:25 +0530
@@ -4047,7 +4085,7 @@ Fix settings regression suite import
 
 ---
 
-## Commit 173: chore: update changelog for v100.17.0
+## Commit 175: chore: update changelog for v100.17.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-26 19:13:03 +0000
@@ -4066,7 +4104,7 @@ chore: update changelog for v100.17.0
 
 ---
 
-## Commit 174: chore: update commit history for v100.17.0
+## Commit 176: chore: update commit history for v100.17.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-26 19:13:01 +0000
@@ -4085,7 +4123,7 @@ chore: update commit history for v100.17.0
 
 ---
 
-## Commit 175: release 100.17.0
+## Commit 177: release 100.17.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-26 19:13:00 +0000
@@ -4104,7 +4142,7 @@ release 100.17.0
 
 ---
 
-## Commit 176: chore: update commit history
+## Commit 178: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-26 16:28:11 +0000
@@ -4123,7 +4161,7 @@ chore: update commit history
 
 ---
 
-## Commit 177: Audit webrequest regression coverage
+## Commit 179: Audit webrequest regression coverage
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-26 21:57:51 +0530
@@ -4152,7 +4190,7 @@ Audit webrequest regression coverage
 
 ---
 
-## Commit 178: chore: update commit history
+## Commit 180: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-26 16:10:03 +0000
@@ -4171,7 +4209,7 @@ chore: update commit history
 
 ---
 
-## Commit 179: Honor method filters for context exceptions
+## Commit 181: Honor method filters for context exceptions
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-26 21:39:27 +0530
@@ -4190,7 +4228,7 @@ Honor method filters for context exceptions
 
 ---
 
-## Commit 180: chore: update commit history
+## Commit 182: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-26 16:05:36 +0000
@@ -4209,7 +4247,7 @@ chore: update commit history
 
 ---
 
-## Commit 181: Fix scoped removeparam context exceptions
+## Commit 183: Fix scoped removeparam context exceptions
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-26 21:34:47 +0530
@@ -4228,7 +4266,7 @@ Fix scoped removeparam context exceptions
 
 ---
 
-## Commit 182: chore: update changelog for v100.16.0
+## Commit 184: chore: update changelog for v100.16.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-26 10:33:54 +0000
@@ -4247,7 +4285,7 @@ chore: update changelog for v100.16.0
 
 ---
 
-## Commit 183: chore: update commit history for v100.16.0
+## Commit 185: chore: update commit history for v100.16.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-26 10:33:53 +0000
@@ -4266,7 +4304,7 @@ chore: update commit history for v100.16.0
 
 ---
 
-## Commit 184: release 100.16.0
+## Commit 186: release 100.16.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-26 10:33:52 +0000
@@ -4285,7 +4323,7 @@ release 100.16.0
 
 ---
 
-## Commit 185: chore: update commit history
+## Commit 187: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-26 10:10:37 +0000
@@ -4304,7 +4342,7 @@ chore: update commit history
 
 ---
 
-## Commit 186: chore: update changelog for v100.15.0
+## Commit 188: chore: update changelog for v100.15.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 19:37:50 +0000
@@ -4323,7 +4361,7 @@ chore: update changelog for v100.15.0
 
 ---
 
-## Commit 187: chore: update commit history for v100.15.0
+## Commit 189: chore: update commit history for v100.15.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 19:37:49 +0000
@@ -4342,7 +4380,7 @@ chore: update commit history for v100.15.0
 
 ---
 
-## Commit 188: release 100.15.0
+## Commit 190: release 100.15.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 19:37:48 +0000
@@ -4361,7 +4399,7 @@ release 100.15.0
 
 ---
 
-## Commit 189: update script
+## Commit 191: update script
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-26 01:06:08 +0530
@@ -4380,7 +4418,7 @@ update script
 
 ---
 
-## Commit 190: chore: update changelog for v100.14.0
+## Commit 192: chore: update changelog for v100.14.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 19:34:20 +0000
@@ -4399,7 +4437,7 @@ chore: update changelog for v100.14.0
 
 ---
 
-## Commit 191: chore: update commit history for v100.14.0
+## Commit 193: chore: update commit history for v100.14.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 19:34:19 +0000
@@ -4418,7 +4456,7 @@ chore: update commit history for v100.14.0
 
 ---
 
-## Commit 192: release 100.14.0
+## Commit 194: release 100.14.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 19:34:18 +0000
@@ -4437,7 +4475,7 @@ release 100.14.0
 
 ---
 
-## Commit 193: update logic
+## Commit 195: update logic
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-26 01:02:37 +0530
@@ -4456,7 +4494,7 @@ update logic
 
 ---
 
-## Commit 194: chore: update changelog for v100.13.0
+## Commit 196: chore: update changelog for v100.13.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 19:13:44 +0000
@@ -4475,7 +4513,7 @@ chore: update changelog for v100.13.0
 
 ---
 
-## Commit 195: chore: update commit history for v100.13.0
+## Commit 197: chore: update commit history for v100.13.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 19:13:42 +0000
@@ -4494,7 +4532,7 @@ chore: update commit history for v100.13.0
 
 ---
 
-## Commit 196: release 100.13.0
+## Commit 198: release 100.13.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 19:13:41 +0000
@@ -4513,7 +4551,7 @@ release 100.13.0
 
 ---
 
-## Commit 197: fix: resolve .build-ignore relative to script file in CI
+## Commit 199: fix: resolve .build-ignore relative to script file in CI
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-26 00:42:46 +0530
@@ -4532,7 +4570,7 @@ fix: resolve .build-ignore relative to script file in CI
 
 ---
 
-## Commit 198: chore: update changelog for v100.12.0
+## Commit 200: chore: update changelog for v100.12.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 18:49:48 +0000
@@ -4551,7 +4589,7 @@ chore: update changelog for v100.12.0
 
 ---
 
-## Commit 199: chore: update commit history for v100.12.0
+## Commit 201: chore: update commit history for v100.12.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 18:49:47 +0000
@@ -4570,7 +4608,7 @@ chore: update commit history for v100.12.0
 
 ---
 
-## Commit 200: release 100.12.0
+## Commit 202: release 100.12.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 18:49:46 +0000
@@ -4589,7 +4627,7 @@ release 100.12.0
 
 ---
 
-## Commit 201: update translations
+## Commit 203: update translations
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-26 00:13:19 +0530
@@ -4661,7 +4699,7 @@ update translations
 
 ---
 
-## Commit 202: chore: update commit history
+## Commit 204: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 17:17:26 +0000
@@ -4680,7 +4718,7 @@ chore: update commit history
 
 ---
 
-## Commit 203: Merge branch 'consolidation' of https://github.com/Linkumori/Linkumori-Addon into consolidation
+## Commit 205: Merge branch 'consolidation' of https://github.com/Linkumori/Linkumori-Addon into consolidation
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-25 22:47:14 +0530
@@ -4699,7 +4737,7 @@ Merge branch 'consolidation' of https://github.com/Linkumori/Linkumori-Addon int
 
 ---
 
-## Commit 204: updated rules
+## Commit 206: updated rules
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-25 22:46:56 +0530
@@ -4719,7 +4757,7 @@ updated rules
 
 ---
 
-## Commit 205: chore: update commit history
+## Commit 207: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 17:13:55 +0000
@@ -4738,7 +4776,7 @@ chore: update commit history
 
 ---
 
-## Commit 206: Address PR review cleanup
+## Commit 208: Address PR review cleanup
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-25 22:43:33 +0530
@@ -4758,7 +4796,7 @@ Address PR review cleanup
 
 ---
 
-## Commit 207: Merge branch 'consolidation' of https://github.com/Linkumori/Linkumori-Addon into consolidation
+## Commit 209: Merge branch 'consolidation' of https://github.com/Linkumori/Linkumori-Addon into consolidation
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-25 22:28:03 +0530
@@ -4777,7 +4815,7 @@ Merge branch 'consolidation' of https://github.com/Linkumori/Linkumori-Addon int
 
 ---
 
-## Commit 208: Merge branch 'main' into consolidation
+## Commit 210: Merge branch 'main' into consolidation
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-25 22:27:48 +0530
@@ -4796,7 +4834,7 @@ Merge branch 'main' into consolidation
 
 ---
 
-## Commit 209: chore: update commit history
+## Commit 211: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 16:51:53 +0000
@@ -4815,7 +4853,7 @@ chore: update commit history
 
 ---
 
-## Commit 210: Align provider context with ClearURLs core
+## Commit 212: Align provider context with ClearURLs core
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-25 22:21:27 +0530
@@ -4837,7 +4875,7 @@ Align provider context with ClearURLs core
 
 ---
 
-## Commit 211: chore: update commit history
+## Commit 213: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 16:35:38 +0000
@@ -4856,7 +4894,7 @@ chore: update commit history
 
 ---
 
-## Commit 212: Polish provider import labels
+## Commit 214: Polish provider import labels
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-25 22:04:45 +0530
@@ -4877,7 +4915,7 @@ Polish provider import labels
 
 ---
 
-## Commit 213: chore: update commit history
+## Commit 215: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 14:46:26 +0000
@@ -4896,7 +4934,7 @@ chore: update commit history
 
 ---
 
-## Commit 214: Merge pull request #133 from Linkumori/consolidation
+## Commit 216: Merge pull request #133 from Linkumori/consolidation
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-25 20:16:14 +0530
@@ -4915,7 +4953,7 @@ Merge pull request #133 from Linkumori/consolidation
 
 ---
 
-## Commit 215: chore: update commit history
+## Commit 217: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 14:43:58 +0000
@@ -4934,7 +4972,7 @@ chore: update commit history
 
 ---
 
-## Commit 216: Address PR review feedback
+## Commit 218: Address PR review feedback
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-25 20:13:29 +0530
@@ -4955,7 +4993,7 @@ Address PR review feedback
 
 ---
 
-## Commit 217: chore: update commit history
+## Commit 219: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 13:52:38 +0000
@@ -4974,7 +5012,7 @@ chore: update commit history
 
 ---
 
-## Commit 218: Align ClearURLs rule identity and provider counts
+## Commit 220: Align ClearURLs rule identity and provider counts
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-25 19:22:06 +0530
@@ -5001,7 +5039,7 @@ Align ClearURLs rule identity and provider counts
 
 ---
 
-## Commit 219: chore: update commit history
+## Commit 221: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 11:33:59 +0000
@@ -5020,7 +5058,7 @@ chore: update commit history
 
 ---
 
-## Commit 220: Pass activation state in regression batch
+## Commit 222: Pass activation state in regression batch
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-25 17:03:29 +0530
@@ -5039,7 +5077,7 @@ Pass activation state in regression batch
 
 ---
 
-## Commit 221: Merge branch 'consolidation' of https://github.com/Linkumori/Linkumori-Addon into consolidation
+## Commit 223: Merge branch 'consolidation' of https://github.com/Linkumori/Linkumori-Addon into consolidation
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-25 16:59:30 +0530
@@ -5058,7 +5096,7 @@ Merge branch 'consolidation' of https://github.com/Linkumori/Linkumori-Addon int
 
 ---
 
-## Commit 222: Merge branch 'main' into consolidation
+## Commit 224: Merge branch 'main' into consolidation
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-25 16:59:13 +0530
@@ -5077,7 +5115,7 @@ Merge branch 'main' into consolidation
 
 ---
 
-## Commit 223: chore: update commit history
+## Commit 225: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 11:29:13 +0000
@@ -5096,7 +5134,7 @@ chore: update commit history
 
 ---
 
-## Commit 224: Merge branch 'consolidation' of https://github.com/Linkumori/Linkumori-Addon into consolidation
+## Commit 226: Merge branch 'consolidation' of https://github.com/Linkumori/Linkumori-Addon into consolidation
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-25 16:58:58 +0530
@@ -5115,7 +5153,7 @@ Merge branch 'consolidation' of https://github.com/Linkumori/Linkumori-Addon int
 
 ---
 
-## Commit 225: deleted useless files
+## Commit 227: deleted useless files
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-25 16:58:38 +0530
@@ -5135,7 +5173,7 @@ deleted useless files
 
 ---
 
-## Commit 226: chore: update commit history
+## Commit 228: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-25 11:26:17 +0000
@@ -5154,7 +5192,7 @@ chore: update commit history
 
 ---
 
-## Commit 227: Align rule activation with ClearURLs origins
+## Commit 229: Align rule activation with ClearURLs origins
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-25 16:55:00 +0530
@@ -5182,7 +5220,7 @@ Align rule activation with ClearURLs origins
 
 ---
 
-## Commit 228: chore: update commit history
+## Commit 230: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-24 17:55:05 +0000
@@ -5201,7 +5239,7 @@ chore: update commit history
 
 ---
 
-## Commit 229: Merge pull request #132 from Linkumori/consolidation
+## Commit 231: Merge pull request #132 from Linkumori/consolidation
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-24 23:24:54 +0530
@@ -5220,7 +5258,7 @@ Merge pull request #132 from Linkumori/consolidation
 
 ---
 
-## Commit 230: chore: update commit history
+## Commit 232: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-24 11:55:09 +0000
@@ -5239,7 +5277,7 @@ chore: update commit history
 
 ---
 
-## Commit 231: fix: thread sessionRewrites set through cleaning loop
+## Commit 233: fix: thread sessionRewrites set through cleaning loop
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-24 17:23:23 +0530
@@ -5259,7 +5297,7 @@ fix: thread sessionRewrites set through cleaning loop
 
 ---
 
-## Commit 232: chore: update commit history
+## Commit 234: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-24 11:33:50 +0000
@@ -5278,7 +5316,7 @@ chore: update commit history
 
 ---
 
-## Commit 233: test: add regression cases for engine improvements
+## Commit 235: test: add regression cases for engine improvements
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-24 16:57:53 +0530
@@ -5297,7 +5335,7 @@ test: add regression cases for engine improvements
 
 ---
 
-## Commit 234: chore: update commit history
+## Commit 236: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-24 11:00:06 +0000
@@ -5316,7 +5354,7 @@ chore: update commit history
 
 ---
 
-## Commit 235: fix: apply PR #130 review fixes
+## Commit 237: fix: apply PR #130 review fixes
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-24 16:42:43 +0530
@@ -5337,7 +5375,7 @@ fix: apply PR #130 review fixes
 
 ---
 
-## Commit 236: chore: update commit history
+## Commit 238: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-23 19:08:10 +0000
@@ -5356,7 +5394,7 @@ chore: update commit history
 
 ---
 
-## Commit 237: feat: engine improvements and dialect documentation consolidation
+## Commit 239: feat: engine improvements and dialect documentation consolidation
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-24 00:37:48 +0530
@@ -5380,7 +5418,7 @@ feat: engine improvements and dialect documentation consolidation
 
 ---
 
-## Commit 238: chore: update changelog for v100.11.0
+## Commit 240: chore: update changelog for v100.11.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-24 03:24:51 +0000
@@ -5399,7 +5437,7 @@ chore: update changelog for v100.11.0
 
 ---
 
-## Commit 239: chore: update commit history for v100.11.0
+## Commit 241: chore: update commit history for v100.11.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-24 03:24:50 +0000
@@ -5418,7 +5456,7 @@ chore: update commit history for v100.11.0
 
 ---
 
-## Commit 240: release 100.11.0
+## Commit 242: release 100.11.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-24 03:24:49 +0000
@@ -5437,7 +5475,7 @@ release 100.11.0
 
 ---
 
-## Commit 241: chore: update commit history
+## Commit 243: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-22 19:27:27 +0000
@@ -5456,7 +5494,7 @@ chore: update commit history
 
 ---
 
-## Commit 242: updated wiki
+## Commit 244: updated wiki
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-23 00:57:01 +0530
@@ -5475,7 +5513,7 @@ updated wiki
 
 ---
 
-## Commit 243: chore: update changelog for v100.10.0
+## Commit 245: chore: update changelog for v100.10.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-22 13:16:25 +0000
@@ -5494,7 +5532,7 @@ chore: update changelog for v100.10.0
 
 ---
 
-## Commit 244: chore: update commit history for v100.10.0
+## Commit 246: chore: update commit history for v100.10.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-22 13:16:23 +0000
@@ -5513,7 +5551,7 @@ chore: update commit history for v100.10.0
 
 ---
 
-## Commit 245: release 100.10.0
+## Commit 247: release 100.10.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-22 13:16:22 +0000
@@ -5532,7 +5570,7 @@ release 100.10.0
 
 ---
 
-## Commit 246: chore: update commit history
+## Commit 248: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-22 11:43:21 +0000
@@ -5551,7 +5589,7 @@ chore: update commit history
 
 ---
 
-## Commit 247: Merge pull request #129 from Linkumori/beta/remove-runtime-snapshot-cleanup
+## Commit 249: Merge pull request #129 from Linkumori/beta/remove-runtime-snapshot-cleanup
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-22 17:13:07 +0530
@@ -5570,7 +5608,7 @@ Merge pull request #129 from Linkumori/beta/remove-runtime-snapshot-cleanup
 
 ---
 
-## Commit 248: chore: update commit history
+## Commit 250: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-22 11:42:22 +0000
@@ -5589,7 +5627,7 @@ chore: update commit history
 
 ---
 
-## Commit 249: Address valid cleanup review feedback
+## Commit 251: Address valid cleanup review feedback
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-22 17:12:03 +0530
@@ -5610,7 +5648,7 @@ Address valid cleanup review feedback
 
 ---
 
-## Commit 250: Merge branch 'main' into beta/remove-runtime-snapshot-cleanup
+## Commit 252: Merge branch 'main' into beta/remove-runtime-snapshot-cleanup
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-22 16:57:57 +0530
@@ -5629,7 +5667,7 @@ Merge branch 'main' into beta/remove-runtime-snapshot-cleanup
 
 ---
 
-## Commit 251: Merge remote-tracking branch 'origin/main' into beta/remove-runtime-snapshot-cleanup
+## Commit 253: Merge remote-tracking branch 'origin/main' into beta/remove-runtime-snapshot-cleanup
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-22 16:57:40 +0530
@@ -5648,7 +5686,7 @@ Merge remote-tracking branch 'origin/main' into beta/remove-runtime-snapshot-cle
 
 ---
 
-## Commit 252: chore: update commit history
+## Commit 254: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-22 11:25:34 +0000
@@ -5667,7 +5705,7 @@ chore: update commit history
 
 ---
 
-## Commit 253: Remove redundant runtime snapshot plumbing
+## Commit 255: Remove redundant runtime snapshot plumbing
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-22 16:55:08 +0530
@@ -5693,7 +5731,7 @@ Remove redundant runtime snapshot plumbing
 
 ---
 
-## Commit 254: chore: update commit history
+## Commit 256: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-22 10:21:28 +0000
@@ -5712,7 +5750,7 @@ chore: update commit history
 
 ---
 
-## Commit 255: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
+## Commit 257: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-22 15:51:12 +0530
@@ -5731,7 +5769,7 @@ Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 ---
 
-## Commit 256: tool.js now integerate with ip-ranger.js
+## Commit 258: tool.js now integerate with ip-ranger.js
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-22 14:36:34 +0530
@@ -5750,7 +5788,7 @@ tool.js now integerate with ip-ranger.js
 
 ---
 
-## Commit 257: chore: update changelog for v100.9.1
+## Commit 259: chore: update changelog for v100.9.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-21 15:47:11 +0000
@@ -5769,7 +5807,7 @@ chore: update changelog for v100.9.1
 
 ---
 
-## Commit 258: chore: update commit history for v100.9.1
+## Commit 260: chore: update commit history for v100.9.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-21 15:47:09 +0000
@@ -5788,7 +5826,7 @@ chore: update commit history for v100.9.1
 
 ---
 
-## Commit 259: release 100.9.1
+## Commit 261: release 100.9.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-21 15:47:08 +0000
@@ -5807,7 +5845,7 @@ release 100.9.1
 
 ---
 
-## Commit 260: chore: update commit history
+## Commit 262: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-21 14:47:17 +0000
@@ -5826,7 +5864,7 @@ chore: update commit history
 
 ---
 
-## Commit 261: fix(regression): fix 5 failing provider snapshot and preprocessor tests
+## Commit 263: fix(regression): fix 5 failing provider snapshot and preprocessor tests
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-21 20:16:52 +0530
@@ -5846,7 +5884,7 @@ fix(regression): fix 5 failing provider snapshot and preprocessor tests
 
 ---
 
-## Commit 262: chore: update commit history
+## Commit 264: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-21 14:05:22 +0000
@@ -5865,7 +5903,7 @@ chore: update commit history
 
 ---
 
-## Commit 263: feat(nav): replace localStorage view state with URL fragment navigation
+## Commit 265: feat(nav): replace localStorage view state with URL fragment navigation
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-21 19:34:55 +0530
@@ -5885,7 +5923,7 @@ feat(nav): replace localStorage view state with URL fragment navigation
 
 ---
 
-## Commit 264: chore: update changelog for v100.9.0
+## Commit 266: chore: update changelog for v100.9.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-21 12:20:54 +0000
@@ -5904,7 +5942,7 @@ chore: update changelog for v100.9.0
 
 ---
 
-## Commit 265: chore: update commit history for v100.9.0
+## Commit 267: chore: update commit history for v100.9.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-21 12:20:53 +0000
@@ -5923,7 +5961,7 @@ chore: update commit history for v100.9.0
 
 ---
 
-## Commit 266: release 100.9.0
+## Commit 268: release 100.9.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-21 12:20:52 +0000
@@ -5942,7 +5980,7 @@ release 100.9.0
 
 ---
 
-## Commit 267: chore: update commit history
+## Commit 269: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-21 12:18:58 +0000
@@ -5961,7 +5999,7 @@ chore: update commit history
 
 ---
 
-## Commit 268: docs(privacy): add Issue Reporting Feature clause and bump consent version
+## Commit 270: docs(privacy): add Issue Reporting Feature clause and bump consent version
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-21 17:48:33 +0530
@@ -5981,7 +6019,7 @@ docs(privacy): add Issue Reporting Feature clause and bump consent version
 
 ---
 
-## Commit 269: chore: update changelog for v100.8.0
+## Commit 271: chore: update changelog for v100.8.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-21 12:11:33 +0000
@@ -6000,7 +6038,7 @@ chore: update changelog for v100.8.0
 
 ---
 
-## Commit 270: chore: update commit history for v100.8.0
+## Commit 272: chore: update commit history for v100.8.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-21 12:11:31 +0000
@@ -6019,7 +6057,7 @@ chore: update commit history for v100.8.0
 
 ---
 
-## Commit 271: release 100.8.0
+## Commit 273: release 100.8.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-21 12:11:30 +0000
@@ -6038,7 +6076,7 @@ release 100.8.0
 
 ---
 
-## Commit 272: chore: update commit history
+## Commit 274: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-21 12:10:31 +0000
@@ -6057,7 +6095,7 @@ chore: update commit history
 
 ---
 
-## Commit 273: feat: add bug report button and GitHub issue report page
+## Commit 275: feat: add bug report button and GitHub issue report page
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-21 17:39:59 +0530
@@ -6146,7 +6184,7 @@ feat: add bug report button and GitHub issue report page
 
 ---
 
-## Commit 274: chore: update commit history
+## Commit 276: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-21 10:08:51 +0000
@@ -6165,7 +6203,7 @@ chore: update commit history
 
 ---
 
-## Commit 275: perf: speed up removeparam matching
+## Commit 277: perf: speed up removeparam matching
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-21 15:37:59 +0530
@@ -6186,7 +6224,7 @@ perf: speed up removeparam matching
 
 ---
 
-## Commit 276: chore: update changelog for v100.7.1
+## Commit 278: chore: update changelog for v100.7.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 17:26:10 +0000
@@ -6205,7 +6243,7 @@ chore: update changelog for v100.7.1
 
 ---
 
-## Commit 277: chore: update commit history for v100.7.1
+## Commit 279: chore: update commit history for v100.7.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 17:26:09 +0000
@@ -6224,7 +6262,7 @@ chore: update commit history for v100.7.1
 
 ---
 
-## Commit 278: release 100.7.1
+## Commit 280: release 100.7.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 17:26:07 +0000
@@ -6243,7 +6281,7 @@ release 100.7.1
 
 ---
 
-## Commit 279: chore: update changelog for v100.7.0
+## Commit 281: chore: update changelog for v100.7.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 17:20:11 +0000
@@ -6262,7 +6300,7 @@ chore: update changelog for v100.7.0
 
 ---
 
-## Commit 280: chore: update commit history for v100.7.0
+## Commit 282: chore: update commit history for v100.7.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 17:20:09 +0000
@@ -6281,7 +6319,7 @@ chore: update commit history for v100.7.0
 
 ---
 
-## Commit 281: release 100.7.0
+## Commit 283: release 100.7.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 17:20:08 +0000
@@ -6300,7 +6338,7 @@ release 100.7.0
 
 ---
 
-## Commit 282: Delete .github/workflows/npm-publish-github-packages.yml
+## Commit 284: Delete .github/workflows/npm-publish-github-packages.yml
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-20 22:47:12 +0530
@@ -6319,7 +6357,7 @@ Delete .github/workflows/npm-publish-github-packages.yml
 
 ---
 
-## Commit 283: Create npm-publish-github-packages.yml
+## Commit 285: Create npm-publish-github-packages.yml
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-20 22:45:56 +0530
@@ -6338,7 +6376,7 @@ Create npm-publish-github-packages.yml
 
 ---
 
-## Commit 284: chore: update changelog for v100.6.1
+## Commit 286: chore: update changelog for v100.6.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 16:25:43 +0000
@@ -6357,7 +6395,7 @@ chore: update changelog for v100.6.1
 
 ---
 
-## Commit 285: chore: update commit history for v100.6.1
+## Commit 287: chore: update commit history for v100.6.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 16:25:42 +0000
@@ -6376,7 +6414,7 @@ chore: update commit history for v100.6.1
 
 ---
 
-## Commit 286: release 100.6.1
+## Commit 288: release 100.6.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 16:25:41 +0000
@@ -6395,7 +6433,7 @@ release 100.6.1
 
 ---
 
-## Commit 287: chore: update commit history
+## Commit 289: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 15:09:50 +0000
@@ -6414,7 +6452,7 @@ chore: update commit history
 
 ---
 
-## Commit 288: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
+## Commit 290: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-20 20:39:27 +0530
@@ -6433,7 +6471,7 @@ Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 ---
 
-## Commit 289: Implement ClearURLs dialect runtime snapshots
+## Commit 291: Implement ClearURLs dialect runtime snapshots
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-20 20:39:19 +0530
@@ -6458,7 +6496,7 @@ Implement ClearURLs dialect runtime snapshots
 
 ---
 
-## Commit 290: chore: update commit history
+## Commit 292: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 14:08:40 +0000
@@ -6477,7 +6515,7 @@ chore: update commit history
 
 ---
 
-## Commit 291: align ClearURLs dialect with core engine
+## Commit 293: align ClearURLs dialect with core engine
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-20 19:38:05 +0530
@@ -6498,7 +6536,7 @@ align ClearURLs dialect with core engine
 
 ---
 
-## Commit 292: chore: update commit history
+## Commit 294: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 10:14:52 +0000
@@ -6517,7 +6555,7 @@ chore: update commit history
 
 ---
 
-## Commit 293: improve regression runner diagnostics
+## Commit 295: improve regression runner diagnostics
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-20 15:44:34 +0530
@@ -6537,7 +6575,7 @@ improve regression runner diagnostics
 
 ---
 
-## Commit 294: chore: update changelog for v100.6.0
+## Commit 296: chore: update changelog for v100.6.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 07:40:42 +0000
@@ -6556,7 +6594,7 @@ chore: update changelog for v100.6.0
 
 ---
 
-## Commit 295: chore: update commit history for v100.6.0
+## Commit 297: chore: update commit history for v100.6.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 07:40:41 +0000
@@ -6575,7 +6613,7 @@ chore: update commit history for v100.6.0
 
 ---
 
-## Commit 296: release 100.6.0
+## Commit 298: release 100.6.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 07:40:40 +0000
@@ -6594,7 +6632,7 @@ release 100.6.0
 
 ---
 
-## Commit 297: chore: update commit history
+## Commit 299: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 07:32:56 +0000
@@ -6613,7 +6651,7 @@ chore: update commit history
 
 ---
 
-## Commit 298: document both custom rule dialects side by side
+## Commit 300: document both custom rule dialects side by side
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-20 13:02:39 +0530
@@ -6632,7 +6670,7 @@ document both custom rule dialects side by side
 
 ---
 
-## Commit 299: chore: update commit history
+## Commit 301: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 07:31:24 +0000
@@ -6651,7 +6689,7 @@ chore: update commit history
 
 ---
 
-## Commit 300: document ClearURLs rule dialects
+## Commit 302: document ClearURLs rule dialects
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-20 13:01:07 +0530
@@ -6671,7 +6709,7 @@ document ClearURLs rule dialects
 
 ---
 
-## Commit 301: chore: update commit history
+## Commit 303: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 07:28:16 +0000
@@ -6690,7 +6728,7 @@ chore: update commit history
 
 ---
 
-## Commit 302: name legacy syntax Linkumori ClearURLs dialect
+## Commit 304: name legacy syntax Linkumori ClearURLs dialect
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-20 12:57:54 +0530
@@ -6764,7 +6802,7 @@ name legacy syntax Linkumori ClearURLs dialect
 
 ---
 
-## Commit 303: chore: update commit history
+## Commit 305: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 07:24:35 +0000
@@ -6783,7 +6821,7 @@ chore: update commit history
 
 ---
 
-## Commit 304: rename v3 editor mode to ClearURLs dialect
+## Commit 306: rename v3 editor mode to ClearURLs dialect
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-20 12:54:16 +0530
@@ -6858,7 +6896,7 @@ rename v3 editor mode to ClearURLs dialect
 
 ---
 
-## Commit 305: chore: update commit history
+## Commit 307: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-20 07:16:59 +0000
@@ -6877,7 +6915,7 @@ chore: update commit history
 
 ---
 
-## Commit 306: fix neutral v3 custom rule templates
+## Commit 308: fix neutral v3 custom rule templates
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-20 12:46:35 +0530
@@ -6951,7 +6989,7 @@ fix neutral v3 custom rule templates
 
 ---
 
-## Commit 307: performance boost for index
+## Commit 309: performance boost for index
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-20 12:30:00 +0530
@@ -6970,7 +7008,7 @@ performance boost for index
 
 ---
 
-## Commit 308: chore: update changelog for v100.5.2
+## Commit 310: chore: update changelog for v100.5.2
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-18 19:35:12 +0000
@@ -6989,7 +7027,7 @@ chore: update changelog for v100.5.2
 
 ---
 
-## Commit 309: chore: update commit history for v100.5.2
+## Commit 311: chore: update commit history for v100.5.2
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-18 19:35:11 +0000
@@ -7008,7 +7046,7 @@ chore: update commit history for v100.5.2
 
 ---
 
-## Commit 310: release 100.5.2
+## Commit 312: release 100.5.2
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-18 19:35:10 +0000
@@ -7027,7 +7065,7 @@ release 100.5.2
 
 ---
 
-## Commit 311: chore: update changelog for v100.5.1
+## Commit 313: chore: update changelog for v100.5.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-18 19:33:08 +0000
@@ -7046,7 +7084,7 @@ chore: update changelog for v100.5.1
 
 ---
 
-## Commit 312: chore: update commit history for v100.5.1
+## Commit 314: chore: update commit history for v100.5.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-18 19:33:07 +0000
@@ -7065,7 +7103,7 @@ chore: update commit history for v100.5.1
 
 ---
 
-## Commit 313: release 100.5.1
+## Commit 315: release 100.5.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-18 19:33:06 +0000
@@ -7084,7 +7122,7 @@ release 100.5.1
 
 ---
 
-## Commit 314: chore: update commit history
+## Commit 316: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-18 19:32:19 +0000
@@ -7103,7 +7141,7 @@ chore: update commit history
 
 ---
 
-## Commit 315: add localized Linkumori v3 editor mode
+## Commit 317: add localized Linkumori v3 editor mode
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-19 01:02:00 +0530
@@ -7178,7 +7216,7 @@ add localized Linkumori v3 editor mode
 
 ---
 
-## Commit 316: chore: update commit history
+## Commit 318: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-18 17:42:42 +0000
@@ -7197,7 +7235,7 @@ chore: update commit history
 
 ---
 
-## Commit 317: Update ci-runner.js
+## Commit 319: Update ci-runner.js
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-18 23:12:20 +0530
@@ -7216,7 +7254,7 @@ Update ci-runner.js
 
 ---
 
-## Commit 318: chore: update commit history
+## Commit 320: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-18 17:42:03 +0000
@@ -7235,7 +7273,7 @@ chore: update commit history
 
 ---
 
-## Commit 319: Update regression-server.js
+## Commit 321: Update regression-server.js
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-18 23:11:41 +0530
@@ -7254,7 +7292,7 @@ Update regression-server.js
 
 ---
 
-## Commit 320: chore: update commit history
+## Commit 322: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-18 16:35:30 +0000
@@ -7273,7 +7311,7 @@ chore: update commit history
 
 ---
 
-## Commit 321: support canonical v2 ClearURLs rules
+## Commit 323: support canonical v2 ClearURLs rules
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-18 22:05:11 +0530
@@ -7292,7 +7330,7 @@ support canonical v2 ClearURLs rules
 
 ---
 
-## Commit 322: chore: update commit history
+## Commit 324: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-18 16:08:35 +0000
@@ -7311,7 +7349,7 @@ chore: update commit history
 
 ---
 
-## Commit 323: support canonical v2 ClearURLs rules
+## Commit 325: support canonical v2 ClearURLs rules
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-18 21:38:13 +0530
@@ -7337,7 +7375,7 @@ support canonical v2 ClearURLs rules
 
 ---
 
-## Commit 324: Merge pull request #1 from Linkumori/dev
+## Commit 326: Merge pull request #1 from Linkumori/dev
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-18 21:24:27 +0530
@@ -7356,7 +7394,7 @@ Merge pull request #1 from Linkumori/dev
 
 ---
 
-## Commit 325: Merge branch 'main' into dev
+## Commit 327: Merge branch 'main' into dev
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-18 20:57:06 +0530
@@ -7375,7 +7413,7 @@ Merge branch 'main' into dev
 
 ---
 
-## Commit 326: chore: update commit history
+## Commit 328: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-18 15:23:29 +0000
@@ -7394,7 +7432,7 @@ chore: update commit history
 
 ---
 
-## Commit 327: chore: update commit history
+## Commit 329: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-18 15:22:48 +0000
@@ -7413,7 +7451,7 @@ chore: update commit history
 
 ---
 
-## Commit 328: add rich syntax support based on clearurls based on dev branch
+## Commit 330: add rich syntax support based on clearurls based on dev branch
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-18 20:52:19 +0530
@@ -7443,7 +7481,7 @@ add rich syntax support based on clearurls based on dev branch
 
 ---
 
-## Commit 329: Revert "fix: harden native rule runtime edge cases"
+## Commit 331: Revert "fix: harden native rule runtime edge cases"
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-18 20:42:12 +0530
@@ -7466,7 +7504,7 @@ Revert "fix: harden native rule runtime edge cases"
 
 ---
 
-## Commit 330: Revert "fix: address native rule review feedback"
+## Commit 332: Revert "fix: address native rule review feedback"
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-18 20:41:24 +0530
@@ -7489,7 +7527,7 @@ Revert "fix: address native rule review feedback"
 
 ---
 
-## Commit 331: Revert "feat: add durable native rule identity support"
+## Commit 333: Revert "feat: add durable native rule identity support"
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-18 20:40:37 +0530
@@ -7569,7 +7607,7 @@ Revert "feat: add durable native rule identity support"
 
 ---
 
-## Commit 332: Revert "feat:(rules): introduce Linkumori-native superset format"
+## Commit 334: Revert "feat:(rules): introduce Linkumori-native superset format"
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-18 20:39:51 +0530
@@ -7592,7 +7630,7 @@ Revert "feat:(rules): introduce Linkumori-native superset format"
 
 ---
 
-## Commit 333: add rich ClearURLs rule syntax support
+## Commit 335: add rich ClearURLs rule syntax support
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-18 20:37:15 +0530
@@ -7616,7 +7654,7 @@ add rich ClearURLs rule syntax support
 
 ---
 
-## Commit 334: chore: update commit history
+## Commit 336: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-18 08:03:52 +0000
@@ -7635,7 +7673,7 @@ chore: update commit history
 
 ---
 
-## Commit 335: fix: harden native rule runtime edge cases
+## Commit 337: fix: harden native rule runtime edge cases
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-18 13:23:32 +0530
@@ -7658,7 +7696,7 @@ fix: harden native rule runtime edge cases
 
 ---
 
-## Commit 336: chore: update commit history
+## Commit 338: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-18 07:18:03 +0000
@@ -7677,7 +7715,7 @@ chore: update commit history
 
 ---
 
-## Commit 337: fix: address native rule review feedback
+## Commit 339: fix: address native rule review feedback
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-18 12:47:29 +0530
@@ -7700,7 +7738,7 @@ fix: address native rule review feedback
 
 ---
 
-## Commit 338: chore: update commit history
+## Commit 340: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-18 02:15:51 +0000
@@ -7719,7 +7757,7 @@ chore: update commit history
 
 ---
 
-## Commit 339: feat: add durable native rule identity support
+## Commit 341: feat: add durable native rule identity support
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-18 07:45:31 +0530
@@ -7799,7 +7837,7 @@ feat: add durable native rule identity support
 
 ---
 
-## Commit 340: chore: update commit history
+## Commit 342: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-18 01:49:58 +0000
@@ -7818,7 +7856,7 @@ chore: update commit history
 
 ---
 
-## Commit 341: Implement native superset rules across tooling
+## Commit 343: Implement native superset rules across tooling
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-18 07:19:41 +0530
@@ -7846,7 +7884,7 @@ Implement native superset rules across tooling
 
 ---
 
-## Commit 342: chore: update commit history
+## Commit 344: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-17 19:11:35 +0000
@@ -7865,7 +7903,7 @@ chore: update commit history
 
 ---
 
-## Commit 343: feat:(rules): introduce Linkumori-native superset format https://gitlab.com/ClearURLs/core/-/merge_requests/4 - Simple removals remain plain strings - Advanced rules use explicit object keys (field/raw/url + remove/rewrite/redirect) - Editor docs, validation, and examples updated to reflect native format
+## Commit 345: feat:(rules): introduce Linkumori-native superset format https://gitlab.com/ClearURLs/core/-/merge_requests/4 - Simple removals remain plain strings - Advanced rules use explicit object keys (field/raw/url + remove/rewrite/redirect) - Editor docs, validation, and examples updated to reflect native format
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-18 00:40:08 +0530
@@ -7888,7 +7926,7 @@ feat:(rules): introduce Linkumori-native superset format https://gitlab.com/Clea
 
 ---
 
-## Commit 344: chore: update commit history
+## Commit 346: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-17 15:11:35 +0000
@@ -7907,7 +7945,7 @@ chore: update commit history
 
 ---
 
-## Commit 345: fix ubo removeparam interoperability
+## Commit 347: fix ubo removeparam interoperability
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-17 20:41:22 +0530
@@ -7928,7 +7966,7 @@ fix ubo removeparam interoperability
 
 ---
 
-## Commit 346: chore: update changelog for v100.5.0
+## Commit 348: chore: update changelog for v100.5.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-17 10:19:42 +0000
@@ -7947,7 +7985,7 @@ chore: update changelog for v100.5.0
 
 ---
 
-## Commit 347: chore: update commit history for v100.5.0
+## Commit 349: chore: update commit history for v100.5.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-17 10:19:41 +0000
@@ -7966,7 +8004,7 @@ chore: update commit history for v100.5.0
 
 ---
 
-## Commit 348: release 100.5.0
+## Commit 350: release 100.5.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-17 10:19:40 +0000
@@ -7985,7 +8023,7 @@ release 100.5.0
 
 ---
 
-## Commit 349: chore: update commit history
+## Commit 351: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-17 10:05:35 +0000
@@ -8004,7 +8042,7 @@ chore: update commit history
 
 ---
 
-## Commit 350: chore: update changelog for v100.4.0
+## Commit 352: chore: update changelog for v100.4.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-17 15:35:14 +0530
@@ -8023,7 +8061,7 @@ chore: update changelog for v100.4.0
 
 ---
 
-## Commit 351: chore: update commit history for v100.4.0
+## Commit 353: chore: update commit history for v100.4.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-17 15:34:41 +0530
@@ -8042,7 +8080,7 @@ chore: update commit history for v100.4.0
 
 ---
 
-## Commit 352: release 100.4.0
+## Commit 354: release 100.4.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-17 15:33:47 +0530
@@ -8061,7 +8099,7 @@ release 100.4.0
 
 ---
 
-## Commit 353: ci: run regression suite as single background batch call
+## Commit 355: ci: run regression suite as single background batch call
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-17 14:34:05 +0530
@@ -8081,7 +8119,7 @@ ci: run regression suite as single background batch call
 
 ---
 
-## Commit 354: chore: update changelog for v100.3.0
+## Commit 356: chore: update changelog for v100.3.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-17 02:53:33 +0000
@@ -8100,7 +8138,7 @@ chore: update changelog for v100.3.0
 
 ---
 
-## Commit 355: chore: update commit history for v100.3.0
+## Commit 357: chore: update commit history for v100.3.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-17 02:53:32 +0000
@@ -8119,7 +8157,7 @@ chore: update commit history for v100.3.0
 
 ---
 
-## Commit 356: release 100.3.0
+## Commit 358: release 100.3.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-17 02:53:31 +0000
@@ -8138,7 +8176,7 @@ release 100.3.0
 
 ---
 
-## Commit 357: chore: update changelog for v100.2.0
+## Commit 359: chore: update changelog for v100.2.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 16:28:05 +0000
@@ -8157,7 +8195,7 @@ chore: update changelog for v100.2.0
 
 ---
 
-## Commit 358: chore: update commit history for v100.2.0
+## Commit 360: chore: update commit history for v100.2.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 16:28:04 +0000
@@ -8176,7 +8214,7 @@ chore: update commit history for v100.2.0
 
 ---
 
-## Commit 359: release 100.2.0
+## Commit 361: release 100.2.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 16:28:03 +0000
@@ -8195,7 +8233,7 @@ release 100.2.0
 
 ---
 
-## Commit 360: chore: update commit history
+## Commit 362: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 16:27:25 +0000
@@ -8214,7 +8252,7 @@ chore: update commit history
 
 ---
 
-## Commit 361: Merge pull request #10 from Linkumori/master
+## Commit 363: Merge pull request #10 from Linkumori/master
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-16 21:57:11 +0530
@@ -8233,7 +8271,7 @@ Merge pull request #10 from Linkumori/master
 
 ---
 
-## Commit 362: Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
+## Commit 364: Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-16 21:56:37 +0530
@@ -8252,7 +8290,7 @@ Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
 
 ---
 
-## Commit 363: Merge branch 'main' into master
+## Commit 365: Merge branch 'main' into master
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-16 21:56:23 +0530
@@ -8271,7 +8309,7 @@ Merge branch 'main' into master
 
 ---
 
-## Commit 364: chore: update commit history
+## Commit 366: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 16:25:29 +0000
@@ -8290,7 +8328,7 @@ chore: update commit history
 
 ---
 
-## Commit 365: chore: update commit history
+## Commit 367: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 13:09:29 +0000
@@ -8309,7 +8347,7 @@ chore: update commit history
 
 ---
 
-## Commit 366: chore: update commit history
+## Commit 368: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 11:52:13 +0000
@@ -8328,7 +8366,7 @@ chore: update commit history
 
 ---
 
-## Commit 367: chore: update changelog for v100.1.0
+## Commit 369: chore: update changelog for v100.1.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 16:18:21 +0000
@@ -8347,7 +8385,7 @@ chore: update changelog for v100.1.0
 
 ---
 
-## Commit 368: chore: update commit history for v100.1.0
+## Commit 370: chore: update commit history for v100.1.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 16:18:20 +0000
@@ -8366,7 +8404,7 @@ chore: update commit history for v100.1.0
 
 ---
 
-## Commit 369: release 100.1.0
+## Commit 371: release 100.1.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 16:18:19 +0000
@@ -8385,7 +8423,7 @@ release 100.1.0
 
 ---
 
-## Commit 370: chore: update changelog for v100.1.0
+## Commit 372: chore: update changelog for v100.1.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 16:18:21 +0000
@@ -8404,7 +8442,7 @@ chore: update changelog for v100.1.0
 
 ---
 
-## Commit 371: chore: update commit history for v100.1.0
+## Commit 373: chore: update commit history for v100.1.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 16:18:20 +0000
@@ -8423,7 +8461,7 @@ chore: update commit history for v100.1.0
 
 ---
 
-## Commit 372: release 100.1.0
+## Commit 374: release 100.1.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 16:18:19 +0000
@@ -8442,7 +8480,7 @@ release 100.1.0
 
 ---
 
-## Commit 373: chore: update commit history
+## Commit 375: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 14:30:35 +0000
@@ -8461,7 +8499,7 @@ chore: update commit history
 
 ---
 
-## Commit 374: ci: skip redundant rule-apply calls and reduce sleeps in CI mode
+## Commit 376: ci: skip redundant rule-apply calls and reduce sleeps in CI mode
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-16 19:59:42 +0530
@@ -8480,7 +8518,7 @@ ci: skip redundant rule-apply calls and reduce sleeps in CI mode
 
 ---
 
-## Commit 375: chore: update commit history
+## Commit 377: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 14:14:39 +0000
@@ -8499,7 +8537,7 @@ chore: update commit history
 
 ---
 
-## Commit 376: ci: log live progress while waiting for regression suite
+## Commit 378: ci: log live progress while waiting for regression suite
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-16 19:44:23 +0530
@@ -8518,7 +8556,7 @@ ci: log live progress while waiting for regression suite
 
 ---
 
-## Commit 377: chore: update commit history
+## Commit 379: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 14:13:27 +0000
@@ -8537,7 +8575,7 @@ chore: update commit history
 
 ---
 
-## Commit 378: ci: auto-detect Firefox binary path per platform
+## Commit 380: ci: auto-detect Firefox binary path per platform
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-16 19:43:10 +0530
@@ -8556,7 +8594,7 @@ ci: auto-detect Firefox binary path per platform
 
 ---
 
-## Commit 379: chore: update commit history
+## Commit 381: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 14:10:31 +0000
@@ -8575,7 +8613,7 @@ chore: update commit history
 
 ---
 
-## Commit 380: ci: skip tab navigation for non-blocked tests in CI mode
+## Commit 382: ci: skip tab navigation for non-blocked tests in CI mode
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-16 19:40:11 +0530
@@ -8595,7 +8633,7 @@ ci: skip tab navigation for non-blocked tests in CI mode
 
 ---
 
-## Commit 381: chore: update commit history
+## Commit 383: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 13:49:56 +0000
@@ -8614,7 +8652,7 @@ chore: update commit history
 
 ---
 
-## Commit 382: ci: add regression test server
+## Commit 384: ci: add regression test server
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-16 19:19:39 +0530
@@ -8633,7 +8671,7 @@ ci: add regression test server
 
 ---
 
-## Commit 383: chore: update commit history
+## Commit 385: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 13:11:07 +0000
@@ -8652,7 +8690,7 @@ chore: update commit history
 
 ---
 
-## Commit 384: ci: use browser-actions to install Firefox and geckodriver
+## Commit 386: ci: use browser-actions to install Firefox and geckodriver
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-16 18:40:51 +0530
@@ -8671,7 +8709,7 @@ ci: use browser-actions to install Firefox and geckodriver
 
 ---
 
-## Commit 385: chore: update commit history
+## Commit 387: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 13:09:29 +0000
@@ -8690,7 +8728,7 @@ chore: update commit history
 
 ---
 
-## Commit 386: ci: add Firefox regression test workflow and CI runner
+## Commit 388: ci: add Firefox regression test workflow and CI runner
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-16 18:39:10 +0530
@@ -8713,7 +8751,7 @@ ci: add Firefox regression test workflow and CI runner
 
 ---
 
-## Commit 387: chore: update commit history
+## Commit 389: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 11:52:13 +0000
@@ -8732,7 +8770,7 @@ chore: update commit history
 
 ---
 
-## Commit 388: fix: untyped removeparam rules default to document type only
+## Commit 390: fix: untyped removeparam rules default to document type only
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-16 17:22:01 +0530
@@ -8751,7 +8789,7 @@ fix: untyped removeparam rules default to document type only
 
 ---
 
-## Commit 389: chore: update commit history
+## Commit 391: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 11:41:05 +0000
@@ -8770,7 +8808,7 @@ chore: update commit history
 
 ---
 
-## Commit 390: fix: regression suite, URL filter interoperability, and AdGuard spec compliance
+## Commit 392: fix: regression suite, URL filter interoperability, and AdGuard spec compliance
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-16 17:09:03 +0530
@@ -8792,7 +8830,7 @@ fix: regression suite, URL filter interoperability, and AdGuard spec compliance
 
 ---
 
-## Commit 391: chore: update changelog for v100.0.4
+## Commit 393: chore: update changelog for v100.0.4
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 05:06:56 +0000
@@ -8811,7 +8849,7 @@ chore: update changelog for v100.0.4
 
 ---
 
-## Commit 392: chore: update commit history for v100.0.4
+## Commit 394: chore: update commit history for v100.0.4
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 05:06:55 +0000
@@ -8830,7 +8868,7 @@ chore: update commit history for v100.0.4
 
 ---
 
-## Commit 393: release 100.0.4
+## Commit 395: release 100.0.4
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 05:06:54 +0000
@@ -8849,7 +8887,7 @@ release 100.0.4
 
 ---
 
-## Commit 394: chore: update commit history
+## Commit 396: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 05:05:19 +0000
@@ -8868,7 +8906,7 @@ chore: update commit history
 
 ---
 
-## Commit 395: Merge pull request #7 from Linkumori/master (add regression suite)
+## Commit 397: Merge pull request #7 from Linkumori/master (add regression suite)
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-16 10:35:05 +0530
@@ -8887,7 +8925,7 @@ Merge pull request #7 from Linkumori/master (add regression suite)
 
 ---
 
-## Commit 396: chore: update commit history
+## Commit 398: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 04:45:00 +0000
@@ -8906,7 +8944,7 @@ chore: update commit history
 
 ---
 
-## Commit 397: exclude regression suite from builds
+## Commit 399: exclude regression suite from builds
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-16 10:14:47 +0530
@@ -8927,7 +8965,7 @@ exclude regression suite from builds
 
 ---
 
-## Commit 398: chore: update commit history
+## Commit 400: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-16 04:40:36 +0000
@@ -8946,7 +8984,7 @@ chore: update commit history
 
 ---
 
-## Commit 399: address regression suite review feedback
+## Commit 401: address regression suite review feedback
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-16 10:10:18 +0530
@@ -9026,7 +9064,7 @@ address regression suite review feedback
 
 ---
 
-## Commit 400: chore: update commit history
+## Commit 402: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-15 19:00:52 +0000
@@ -9045,7 +9083,7 @@ chore: update commit history
 
 ---
 
-## Commit 401: add in-extension regression suite runner
+## Commit 403: add in-extension regression suite runner
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-16 00:30:34 +0530
@@ -9071,7 +9109,7 @@ add in-extension regression suite runner
 
 ---
 
-## Commit 402: chore: update commit history
+## Commit 404: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-15 13:02:17 +0000
@@ -9090,7 +9128,7 @@ chore: update commit history
 
 ---
 
-## Commit 403: chore: update changelog for v100.0.3
+## Commit 405: chore: update changelog for v100.0.3
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-15 12:48:10 +0000
@@ -9109,7 +9147,7 @@ chore: update changelog for v100.0.3
 
 ---
 
-## Commit 404: chore: update commit history for v100.0.3
+## Commit 406: chore: update commit history for v100.0.3
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-15 12:48:08 +0000
@@ -9128,7 +9166,7 @@ chore: update commit history for v100.0.3
 
 ---
 
-## Commit 405: release 100.0.3
+## Commit 407: release 100.0.3
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-15 12:48:07 +0000
@@ -9148,7 +9186,7 @@ release 100.0.3
 
 ---
 
-## Commit 406: chore: update commit history
+## Commit 408: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-15 12:47:13 +0000
@@ -9167,7 +9205,7 @@ chore: update commit history
 
 ---
 
-## Commit 407: Merge pull request #6 from Linkumori/master
+## Commit 409: Merge pull request #6 from Linkumori/master
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-15 18:16:58 +0530
@@ -9186,7 +9224,7 @@ Merge pull request #6 from Linkumori/master
 
 ---
 
-## Commit 408: chore: update commit history
+## Commit 410: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-15 12:46:00 +0000
@@ -9205,7 +9243,7 @@ chore: update commit history
 
 ---
 
-## Commit 409: Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
+## Commit 411: Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-15 18:15:46 +0530
@@ -9224,7 +9262,7 @@ Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
 
 ---
 
-## Commit 410: remove inferred main frame source fallback
+## Commit 412: remove inferred main frame source fallback
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-15 18:15:36 +0530
@@ -9244,7 +9282,7 @@ remove inferred main frame source fallback
 
 ---
 
-## Commit 411: chore: update commit history
+## Commit 413: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-15 12:39:05 +0000
@@ -9263,7 +9301,7 @@ chore: update commit history
 
 ---
 
-## Commit 412: Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
+## Commit 414: Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-15 18:08:40 +0530
@@ -9282,7 +9320,7 @@ Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
 
 ---
 
-## Commit 413: address pr review feedback
+## Commit 415: address pr review feedback
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-15 18:07:47 +0530
@@ -9305,7 +9343,7 @@ address pr review feedback
 
 ---
 
-## Commit 414: chore: update commit history
+## Commit 416: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-15 12:28:16 +0000
@@ -9324,7 +9362,7 @@ chore: update commit history
 
 ---
 
-## Commit 415: Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
+## Commit 417: Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-15 17:57:40 +0530
@@ -9343,7 +9381,7 @@ Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
 
 ---
 
-## Commit 416: fix url filter syntax handling and provider indexing
+## Commit 418: fix url filter syntax handling and provider indexing
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-15 17:57:16 +0530
@@ -9369,7 +9407,7 @@ fix url filter syntax handling and provider indexing
 
 ---
 
-## Commit 417: chore: update commit history
+## Commit 419: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 19:07:19 +0000
@@ -9388,7 +9426,7 @@ chore: update commit history
 
 ---
 
-## Commit 418: chore: update changelog for v100.0.2
+## Commit 420: chore: update changelog for v100.0.2
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 19:05:52 +0000
@@ -9407,7 +9445,7 @@ chore: update changelog for v100.0.2
 
 ---
 
-## Commit 419: chore: update commit history for v100.0.2
+## Commit 421: chore: update commit history for v100.0.2
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 19:05:51 +0000
@@ -9426,7 +9464,7 @@ chore: update commit history for v100.0.2
 
 ---
 
-## Commit 420: release 100.0.2
+## Commit 422: release 100.0.2
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 19:05:50 +0000
@@ -9446,7 +9484,7 @@ release 100.0.2
 
 ---
 
-## Commit 421: chore: update commit history
+## Commit 423: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 16:17:21 +0000
@@ -9465,7 +9503,7 @@ chore: update commit history
 
 ---
 
-## Commit 422: Merge pull request #5 from Linkumori/master
+## Commit 424: Merge pull request #5 from Linkumori/master
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 21:46:49 +0530
@@ -9484,7 +9522,7 @@ Merge pull request #5 from Linkumori/master
 
 ---
 
-## Commit 423: chore: update commit history
+## Commit 425: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 16:16:25 +0000
@@ -9503,7 +9541,7 @@ chore: update commit history
 
 ---
 
-## Commit 424: recompile from same source code using new version of fontforge
+## Commit 426: recompile from same source code using new version of fontforge
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 21:44:45 +0530
@@ -9522,7 +9560,7 @@ recompile from same source code using new version of fontforge
 
 ---
 
-## Commit 425: chore: update changelog for v100.0.1
+## Commit 427: chore: update changelog for v100.0.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 13:22:13 +0000
@@ -9541,7 +9579,7 @@ chore: update changelog for v100.0.1
 
 ---
 
-## Commit 426: chore: update commit history for v100.0.1
+## Commit 428: chore: update commit history for v100.0.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 13:22:12 +0000
@@ -9560,7 +9598,7 @@ chore: update commit history for v100.0.1
 
 ---
 
-## Commit 427: release 100.0.1
+## Commit 429: release 100.0.1
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 13:22:11 +0000
@@ -9579,7 +9617,7 @@ release 100.0.1
 
 ---
 
-## Commit 428: chore: update commit history
+## Commit 430: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 13:20:21 +0000
@@ -9598,7 +9636,7 @@ chore: update commit history
 
 ---
 
-## Commit 429: Merge pull request #4 from Linkumori/master
+## Commit 431: Merge pull request #4 from Linkumori/master
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 18:50:04 +0530
@@ -9617,7 +9655,7 @@ Merge pull request #4 from Linkumori/master
 
 ---
 
-## Commit 430: chore: update commit history
+## Commit 432: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 09:58:03 +0000
@@ -9636,7 +9674,7 @@ chore: update commit history
 
 ---
 
-## Commit 431: chore: update commit history
+## Commit 433: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 13:12:30 +0000
@@ -9655,7 +9693,7 @@ chore: update commit history
 
 ---
 
-## Commit 432: changed to manfiest.json
+## Commit 434: changed to manfiest.json
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 18:41:31 +0530
@@ -9674,7 +9712,7 @@ changed to manfiest.json
 
 ---
 
-## Commit 433: chore: update commit history
+## Commit 435: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 13:11:43 +0000
@@ -9693,7 +9731,7 @@ chore: update commit history
 
 ---
 
-## Commit 434: ci: add stable and patch version semantics
+## Commit 436: ci: add stable and patch version semantics
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 18:41:19 +0530
@@ -9712,7 +9750,7 @@ ci: add stable and patch version semantics
 
 ---
 
-## Commit 435: chore: update commit history
+## Commit 437: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 09:58:03 +0000
@@ -9731,7 +9769,7 @@ chore: update commit history
 
 ---
 
-## Commit 436: Merge pull request #3 from Linkumori/master
+## Commit 438: Merge pull request #3 from Linkumori/master
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 15:27:51 +0530
@@ -9750,7 +9788,7 @@ Merge pull request #3 from Linkumori/master
 
 ---
 
-## Commit 437: chore: update commit history
+## Commit 439: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 09:11:54 +0000
@@ -9769,7 +9807,7 @@ chore: update commit history
 
 ---
 
-## Commit 438: fix inaccuracy in README.MD
+## Commit 440: fix inaccuracy in README.MD
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 14:41:08 +0530
@@ -9788,7 +9826,7 @@ fix inaccuracy in README.MD
 
 ---
 
-## Commit 439: chore: update commit history
+## Commit 441: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 08:28:26 +0000
@@ -9807,7 +9845,7 @@ chore: update commit history
 
 ---
 
-## Commit 440: updated package-lock.json
+## Commit 442: updated package-lock.json
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 13:57:46 +0530
@@ -9826,7 +9864,7 @@ updated package-lock.json
 
 ---
 
-## Commit 441: chore: update changelog for v67.0
+## Commit 443: chore: update changelog for v67.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 08:12:38 +0000
@@ -9845,7 +9883,7 @@ chore: update changelog for v67.0
 
 ---
 
-## Commit 442: chore: update commit history for v67.0
+## Commit 444: chore: update commit history for v67.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 08:12:36 +0000
@@ -9864,7 +9902,7 @@ chore: update commit history for v67.0
 
 ---
 
-## Commit 443: release 67.0
+## Commit 445: release 67.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 08:12:35 +0000
@@ -9883,7 +9921,7 @@ release 67.0
 
 ---
 
-## Commit 444: chore: update commit history
+## Commit 446: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 08:10:40 +0000
@@ -9902,7 +9940,7 @@ chore: update commit history
 
 ---
 
-## Commit 445: Merge pull request #2 from Linkumori/master
+## Commit 447: Merge pull request #2 from Linkumori/master
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 13:40:21 +0530
@@ -9921,7 +9959,7 @@ Merge pull request #2 from Linkumori/master
 
 ---
 
-## Commit 446: chore: update commit history
+## Commit 448: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 08:09:44 +0000
@@ -9940,7 +9978,7 @@ chore: update commit history
 
 ---
 
-## Commit 447: Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
+## Commit 449: Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 13:38:48 +0530
@@ -9959,7 +9997,7 @@ Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
 
 ---
 
-## Commit 448: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
+## Commit 450: Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 13:38:08 +0530
@@ -9978,7 +10016,7 @@ Merge branch 'main' of https://github.com/Linkumori/Linkumori-Addon
 
 ---
 
-## Commit 449: chore: update commit history
+## Commit 451: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 08:07:53 +0000
@@ -9997,7 +10035,7 @@ chore: update commit history
 
 ---
 
-## Commit 450: Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
+## Commit 452: Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 13:37:38 +0530
@@ -10016,7 +10054,7 @@ Merge branch 'master' of https://github.com/Linkumori/Linkumori-Addon
 
 ---
 
-## Commit 451: add updated rules
+## Commit 453: add updated rules
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 13:37:17 +0530
@@ -10036,7 +10074,7 @@ add updated rules
 
 ---
 
-## Commit 452: chore: update commit history
+## Commit 454: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 08:06:16 +0000
@@ -10055,7 +10093,7 @@ chore: update commit history
 
 ---
 
-## Commit 453: Merge pull request #1 from Linkumori/master refactor: unify url filter rules under ClearURLsData
+## Commit 455: Merge pull request #1 from Linkumori/master refactor: unify url filter rules under ClearURLsData
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 13:36:01 +0530
@@ -10074,7 +10112,7 @@ Merge pull request #1 from Linkumori/master refactor: unify url filter rules und
 
 ---
 
-## Commit 454: chore: update commit history
+## Commit 456: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 08:03:32 +0000
@@ -10093,7 +10131,7 @@ chore: update commit history
 
 ---
 
-## Commit 455: fix: address PR review findings
+## Commit 457: fix: address PR review findings
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 13:33:12 +0530
@@ -10115,7 +10153,7 @@ fix: address PR review findings
 
 ---
 
-## Commit 456: chore: update commit history
+## Commit 458: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 07:54:31 +0000
@@ -10134,7 +10172,7 @@ chore: update commit history
 
 ---
 
-## Commit 457: fix: align settings import with unified ClearURLsData
+## Commit 459: fix: align settings import with unified ClearURLsData
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 13:24:09 +0530
@@ -10154,7 +10192,7 @@ fix: align settings import with unified ClearURLsData
 
 ---
 
-## Commit 458: chore: update commit history
+## Commit 460: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 07:50:09 +0000
@@ -10173,7 +10211,7 @@ chore: update commit history
 
 ---
 
-## Commit 459: refactor: unify CLI clearurls URL filter output
+## Commit 461: refactor: unify CLI clearurls URL filter output
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 13:19:44 +0530
@@ -10195,7 +10233,7 @@ refactor: unify CLI clearurls URL filter output
 
 ---
 
-## Commit 460: chore: update commit history
+## Commit 462: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 07:44:13 +0000
@@ -10214,7 +10252,7 @@ chore: update commit history
 
 ---
 
-## Commit 461: refactor: unify url filter rules under ClearURLsData
+## Commit 463: refactor: unify url filter rules under ClearURLsData
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 13:13:40 +0530
@@ -10241,7 +10279,7 @@ refactor: unify url filter rules under ClearURLsData
 
 ---
 
-## Commit 462: chore: update commit history
+## Commit 464: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 07:21:17 +0000
@@ -10260,7 +10298,7 @@ chore: update commit history
 
 ---
 
-## Commit 463: docs: add maintainer wiki and refresh rule syntax
+## Commit 465: docs: add maintainer wiki and refresh rule syntax
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 12:50:52 +0530
@@ -10288,7 +10326,7 @@ docs: add maintainer wiki and refresh rule syntax
 
 ---
 
-## Commit 464: chore: update commit history
+## Commit 466: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 06:27:35 +0000
@@ -10307,7 +10345,7 @@ chore: update commit history
 
 ---
 
-## Commit 465: Tighten index pattern extraction
+## Commit 467: Tighten index pattern extraction
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 11:57:17 +0530
@@ -10328,7 +10366,7 @@ Tighten index pattern extraction
 
 ---
 
-## Commit 466: chore: update commit history
+## Commit 468: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 05:49:29 +0000
@@ -10347,7 +10385,7 @@ chore: update commit history
 
 ---
 
-## Commit 467: Improve trie persistence and index pattern generation
+## Commit 469: Improve trie persistence and index pattern generation
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 11:18:32 +0530
@@ -10371,7 +10409,7 @@ Improve trie persistence and index pattern generation
 
 ---
 
-## Commit 468: removed more stuff for enchanced speed
+## Commit 470: removed more stuff for enchanced speed
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 07:47:46 +0530
@@ -10390,7 +10428,7 @@ removed more stuff for enchanced speed
 
 ---
 
-## Commit 469: chore: update changelog for v66.0
+## Commit 471: chore: update changelog for v66.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 00:51:23 +0000
@@ -10409,7 +10447,7 @@ chore: update changelog for v66.0
 
 ---
 
-## Commit 470: chore: update commit history for v66.0
+## Commit 472: chore: update commit history for v66.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 00:51:22 +0000
@@ -10428,7 +10466,7 @@ chore: update commit history for v66.0
 
 ---
 
-## Commit 471: release 66.0
+## Commit 473: release 66.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-13 00:51:21 +0000
@@ -10447,7 +10485,7 @@ release 66.0
 
 ---
 
-## Commit 472: chore: update commit history
+## Commit 474: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-12 19:34:58 +0000
@@ -10466,7 +10504,7 @@ chore: update commit history
 
 ---
 
-## Commit 473: updated index logic and update matching logic
+## Commit 475: updated index logic and update matching logic
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 01:04:15 +0530
@@ -10488,7 +10526,7 @@ updated index logic and update matching logic
 
 ---
 
-## Commit 474: chore: update commit history
+## Commit 476: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-12 18:56:22 +0000
@@ -10507,7 +10545,7 @@ chore: update commit history
 
 ---
 
-## Commit 475: removed useless fuction to get best speed
+## Commit 477: removed useless fuction to get best speed
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 00:25:38 +0530
@@ -10526,7 +10564,7 @@ removed useless fuction to get best speed
 
 ---
 
-## Commit 476: chore: update changelog for v65.0
+## Commit 478: chore: update changelog for v65.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-12 18:42:51 +0000
@@ -10545,7 +10583,7 @@ chore: update changelog for v65.0
 
 ---
 
-## Commit 477: chore: update commit history for v65.0
+## Commit 479: chore: update commit history for v65.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-12 18:42:50 +0000
@@ -10564,7 +10602,7 @@ chore: update commit history for v65.0
 
 ---
 
-## Commit 478: release 65.0
+## Commit 480: release 65.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-12 18:42:49 +0000
@@ -10583,7 +10621,7 @@ release 65.0
 
 ---
 
-## Commit 479: chore: update commit history
+## Commit 481: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-12 18:40:38 +0000
@@ -10602,7 +10640,7 @@ chore: update commit history
 
 ---
 
-## Commit 480: add rules with index with cli updated
+## Commit 482: add rules with index with cli updated
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-13 00:03:18 +0530
@@ -10623,7 +10661,7 @@ add rules with index with cli updated
 
 ---
 
-## Commit 481: feat: updated all translation added multiple indexpattern in one provider and some bug fixes
+## Commit 483: feat: updated all translation added multiple indexpattern in one provider and some bug fixes
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-12 23:37:07 +0530
@@ -10698,7 +10736,7 @@ feat: updated all translation added multiple indexpattern in one provider and so
 
 ---
 
-## Commit 482: chore: update commit history
+## Commit 484: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-12 15:54:55 +0000
@@ -10717,7 +10755,7 @@ chore: update commit history
 
 ---
 
-## Commit 483: feat: added index pattern in other subsytem
+## Commit 485: feat: added index pattern in other subsytem
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-12 20:33:43 +0530
@@ -10740,7 +10778,7 @@ feat: added index pattern in other subsytem
 
 ---
 
-## Commit 484: chore: update commit history
+## Commit 486: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-12 15:44:35 +0000
@@ -10759,7 +10797,7 @@ chore: update commit history
 
 ---
 
-## Commit 485: chore: update changelog for v64.0
+## Commit 487: chore: update changelog for v64.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-12 07:46:08 +0000
@@ -10778,7 +10816,7 @@ chore: update changelog for v64.0
 
 ---
 
-## Commit 486: chore: update commit history for v64.0
+## Commit 488: chore: update commit history for v64.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-12 07:46:07 +0000
@@ -10797,7 +10835,7 @@ chore: update commit history for v64.0
 
 ---
 
-## Commit 487: release 64.0
+## Commit 489: release 64.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-12 07:46:07 +0000
@@ -10816,7 +10854,7 @@ release 64.0
 
 ---
 
-## Commit 488: chore: update changelog for v63.0
+## Commit 490: chore: update changelog for v63.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-12 07:43:25 +0000
@@ -10835,7 +10873,7 @@ chore: update changelog for v63.0
 
 ---
 
-## Commit 489: chore: update commit history for v63.0
+## Commit 491: chore: update commit history for v63.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-12 07:43:24 +0000
@@ -10854,7 +10892,7 @@ chore: update commit history for v63.0
 
 ---
 
-## Commit 490: release 63.0
+## Commit 492: release 63.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-12 07:43:23 +0000
@@ -10873,7 +10911,7 @@ release 63.0
 
 ---
 
-## Commit 491: chore: update commit history
+## Commit 493: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-12 07:41:48 +0000
@@ -10892,7 +10930,7 @@ chore: update commit history
 
 ---
 
-## Commit 492: change linkumori to "ClearURLs(Linkumori)" in manifest.json
+## Commit 494: change linkumori to "ClearURLs(Linkumori)" in manifest.json
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-12 13:11:01 +0530
@@ -10911,7 +10949,7 @@ change linkumori to "ClearURLs(Linkumori)" in manifest.json
 
 ---
 
-## Commit 493: chore: update commit history
+## Commit 495: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-11 15:49:46 +0000
@@ -10930,7 +10968,7 @@ chore: update commit history
 
 ---
 
-## Commit 494: Merge pull request #1 from Linkumori/subham8907-patch-1
+## Commit 496: Merge pull request #1 from Linkumori/subham8907-patch-1
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-11 21:19:24 +0530
@@ -10949,7 +10987,7 @@ Merge pull request #1 from Linkumori/subham8907-patch-1
 
 ---
 
-## Commit 495: chore: update commit history
+## Commit 497: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-11 15:38:14 +0000
@@ -10968,7 +11006,7 @@ chore: update commit history
 
 ---
 
-## Commit 496: feat(provider-index): replace regex-heuristic token extraction with explicit indexPattern; add regex literal support in domainPatterns  ── Problem ──────────────────────────────────────────────────────────  providersByToken was populated by getLookupToken(), which parsed the urlPattern regex source to guess which hostname the provider targets. This approach had three compounding failure modes:  1. Alternation groups like (?:youtube\.com
+## Commit 498: feat(provider-index): replace regex-heuristic token extraction with explicit indexPattern; add regex literal support in domainPatterns  ── Problem ──────────────────────────────────────────────────────────  providersByToken was populated by getLookupToken(), which parsed the urlPattern regex source to guess which hostname the provider targets. This approach had three compounding failure modes:  1. Alternation groups like (?:youtube\.com
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-11 21:07:56 +0530
@@ -10987,7 +11025,7 @@ feat(provider-index): replace regex-heuristic token extraction with explicit ind
 
 ---
 
-## Commit 497: chore: update changelog for v62.0
+## Commit 499: chore: update changelog for v62.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-11 15:21:30 +0000
@@ -11006,7 +11044,7 @@ chore: update changelog for v62.0
 
 ---
 
-## Commit 498: chore: update commit history for v62.0
+## Commit 500: chore: update commit history for v62.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-11 15:21:29 +0000
@@ -11025,7 +11063,7 @@ chore: update commit history for v62.0
 
 ---
 
-## Commit 499: release 62.0
+## Commit 501: release 62.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-11 15:21:27 +0000
@@ -11044,7 +11082,7 @@ release 62.0
 
 ---
 
-## Commit 500: chore: update commit history
+## Commit 502: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-11 15:20:18 +0000
@@ -11063,7 +11101,7 @@ chore: update commit history
 
 ---
 
-## Commit 501: Update manifest.json
+## Commit 503: Update manifest.json
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-11 20:50:00 +0530
@@ -11082,7 +11120,7 @@ Update manifest.json
 
 ---
 
-## Commit 502: chore: update commit history
+## Commit 504: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-11 09:11:05 +0000
@@ -11101,7 +11139,7 @@ chore: update commit history
 
 ---
 
-## Commit 503: chore: update changelog for v60.0
+## Commit 505: chore: update changelog for v60.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-10 02:25:28 +0000
@@ -11120,7 +11158,7 @@ chore: update changelog for v60.0
 
 ---
 
-## Commit 504: chore: update commit history for v60.0
+## Commit 506: chore: update commit history for v60.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-10 02:25:27 +0000
@@ -11139,7 +11177,7 @@ chore: update commit history for v60.0
 
 ---
 
-## Commit 505: release 60.0
+## Commit 507: release 60.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-10 02:25:26 +0000
@@ -11158,7 +11196,7 @@ release 60.0
 
 ---
 
-## Commit 506: chore: update commit history
+## Commit 508: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-09 11:21:19 +0000
@@ -11177,7 +11215,7 @@ chore: update commit history
 
 ---
 
-## Commit 507: Merge pull request #1 from Linkumori/beta_performance
+## Commit 509: Merge pull request #1 from Linkumori/beta_performance
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-09 16:51:07 +0530
@@ -11196,7 +11234,7 @@ Merge pull request #1 from Linkumori/beta_performance
 
 ---
 
-## Commit 508: chore: update commit history
+## Commit 510: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-09 10:57:16 +0000
@@ -11215,7 +11253,7 @@ chore: update commit history
 
 ---
 
-## Commit 509: we taken some of patches from clearurls https://gitlab.com/ClearURLs/ClearUrls/-/blob/refactoring/clearurls.js?ref_type=heads and adapt from it to our codebase. We have made some modifications to the original code to fit our requirements and improve performance.
+## Commit 511: we taken some of patches from clearurls https://gitlab.com/ClearURLs/ClearUrls/-/blob/refactoring/clearurls.js?ref_type=heads and adapt from it to our codebase. We have made some modifications to the original code to fit our requirements and improve performance.
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-09 16:04:46 +0530
@@ -11234,7 +11272,7 @@ we taken some of patches from clearurls https://gitlab.com/ClearURLs/ClearUrls/-
 
 ---
 
-## Commit 510: chore: update commit history
+## Commit 512: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-08 18:38:01 +0000
@@ -11253,7 +11291,7 @@ chore: update commit history
 
 ---
 
-## Commit 511: Update privacy-policy-cli.md
+## Commit 513: Update privacy-policy-cli.md
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-09 00:07:47 +0530
@@ -11272,7 +11310,7 @@ Update privacy-policy-cli.md
 
 ---
 
-## Commit 512: chore: update changelog for v59.0
+## Commit 514: chore: update changelog for v59.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-08 11:15:26 +0000
@@ -11291,7 +11329,7 @@ chore: update changelog for v59.0
 
 ---
 
-## Commit 513: chore: update commit history for v59.0
+## Commit 515: chore: update commit history for v59.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-08 11:15:25 +0000
@@ -11310,7 +11348,7 @@ chore: update commit history for v59.0
 
 ---
 
-## Commit 514: release 59.0
+## Commit 516: release 59.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-08 11:15:24 +0000
@@ -11329,7 +11367,7 @@ release 59.0
 
 ---
 
-## Commit 515: chore: update commit history
+## Commit 517: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-08 11:11:57 +0000
@@ -11348,7 +11386,7 @@ chore: update commit history
 
 ---
 
-## Commit 516: feat: add Firefox CNAME uncloaking controls
+## Commit 518: feat: add Firefox CNAME uncloaking controls
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-08 16:40:55 +0530
@@ -11426,7 +11464,7 @@ feat: add Firefox CNAME uncloaking controls
 
 ---
 
-## Commit 517: chore: update changelog for v58.0
+## Commit 519: chore: update changelog for v58.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-08 07:48:57 +0000
@@ -11445,7 +11483,7 @@ chore: update changelog for v58.0
 
 ---
 
-## Commit 518: chore: update commit history for v58.0
+## Commit 520: chore: update commit history for v58.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-08 07:48:55 +0000
@@ -11464,7 +11502,7 @@ chore: update commit history for v58.0
 
 ---
 
-## Commit 519: release 58.0
+## Commit 521: release 58.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-08 07:48:54 +0000
@@ -11483,7 +11521,7 @@ release 58.0
 
 ---
 
-## Commit 520: chore: update commit history
+## Commit 522: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-08 06:53:53 +0000
@@ -11502,7 +11540,7 @@ chore: update commit history
 
 ---
 
-## Commit 521: Update privacy-policy-cli.md
+## Commit 523: Update privacy-policy-cli.md
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-08 12:23:34 +0530
@@ -11521,7 +11559,7 @@ Update privacy-policy-cli.md
 
 ---
 
-## Commit 522: chore: update changelog for v57.0
+## Commit 524: chore: update changelog for v57.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-08 05:54:48 +0000
@@ -11540,7 +11578,7 @@ chore: update changelog for v57.0
 
 ---
 
-## Commit 523: chore: update commit history for v57.0
+## Commit 525: chore: update commit history for v57.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-08 05:54:47 +0000
@@ -11559,7 +11597,7 @@ chore: update commit history for v57.0
 
 ---
 
-## Commit 524: release 57.0
+## Commit 526: release 57.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-08 05:54:46 +0000
@@ -11578,7 +11616,7 @@ release 57.0
 
 ---
 
-## Commit 525: chore: update commit history
+## Commit 527: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-08 05:54:03 +0000
@@ -11597,7 +11635,7 @@ chore: update commit history
 
 ---
 
-## Commit 526: feat: add Firefox DNS CNAME uncloaking and localized settings toggle
+## Commit 528: feat: add Firefox DNS CNAME uncloaking and localized settings toggle
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-08 11:21:50 +0530
@@ -11683,7 +11721,7 @@ feat: add Firefox DNS CNAME uncloaking and localized settings toggle
 
 ---
 
-## Commit 527: chore: update commit history
+## Commit 529: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-07 03:39:22 +0000
@@ -11702,7 +11740,7 @@ chore: update commit history
 
 ---
 
-## Commit 528: Fix deprecated Components warning
+## Commit 530: Fix deprecated Components warning
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-07 09:07:23 +0530
@@ -11723,7 +11761,7 @@ Fix deprecated Components warning
 
 ---
 
-## Commit 529: chore: update commit history
+## Commit 531: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-07 02:27:49 +0000
@@ -11742,7 +11780,7 @@ chore: update commit history
 
 ---
 
-## Commit 530: reverse some change made earlier reapplied
+## Commit 532: reverse some change made earlier reapplied
 
 **Author**: Linkumori <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-07 07:56:57 +0530
@@ -11761,7 +11799,7 @@ reverse some change made earlier reapplied
 
 ---
 
-## Commit 531: chore: update commit history
+## Commit 533: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-07 01:59:03 +0000
@@ -11780,7 +11818,7 @@ chore: update commit history
 
 ---
 
-## Commit 532: Update audit.js
+## Commit 534: Update audit.js
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-07 07:28:53 +0530
@@ -11799,7 +11837,7 @@ Update audit.js
 
 ---
 
-## Commit 533: chore: update changelog for v56.0
+## Commit 535: chore: update changelog for v56.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-06 23:10:21 +0000
@@ -11818,7 +11856,7 @@ chore: update changelog for v56.0
 
 ---
 
-## Commit 534: chore: update commit history for v56.0
+## Commit 536: chore: update commit history for v56.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-06 23:10:19 +0000
@@ -11837,7 +11875,7 @@ chore: update commit history for v56.0
 
 ---
 
-## Commit 535: release 56.0
+## Commit 537: release 56.0
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-06 23:10:18 +0000
@@ -11861,7 +11899,7 @@ release 56.0
 
 ---
 
-## Commit 536: chore: update commit history
+## Commit 538: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-06 23:09:44 +0000
@@ -11880,7 +11918,7 @@ chore: update commit history
 
 ---
 
-## Commit 537: Update manifest.json
+## Commit 539: Update manifest.json
 
 **Author**: Subham Mahesh <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-07 04:39:32 +0530
@@ -11899,7 +11937,7 @@ Update manifest.json
 
 ---
 
-## Commit 538: chore: update commit history
+## Commit 540: chore: update commit history
 
 **Author**: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
 **Date**: 2026-05-06 23:04:03 +0000
@@ -11918,7 +11956,7 @@ chore: update commit history
 
 ---
 
-## Commit 539: linkumori release
+## Commit 541: linkumori release
 
 **Author**: subham8907 <142691487+subham8907@users.noreply.github.com>
 **Date**: 2026-05-07 04:32:17 +0530
@@ -12218,4 +12256,4 @@ linkumori release
 
 *End of Commit History*
 
-**Generated by Linkumori CLI** - 2026-08-05T16:12:49.320Z
+**Generated by Linkumori CLI** - 2026-08-05T16:14:25.767Z

--- a/tests/ci-runner.js
+++ b/tests/ci-runner.js
@@ -200,8 +200,10 @@ async function buildExtension() {
 }
 
 async function launchDriver(xpiPath) {
+    // -remote-allow-system-access is required (Firefox 138+) for the
+    // Marionette chrome-context fallback in navigateToExtensionPage.
     const options = new firefox.Options()
-        .addArguments('-headless')
+        .addArguments('-headless', '-remote-allow-system-access')
         .setPreference('extensions.webextensions.uuids', JSON.stringify({ [EXTENSION_ID]: EXTENSION_UUID }))
         .setPreference('xpinstall.signatures.required', false)
         .setPreference('extensions.langpacks.signatures.required', false)


### PR DESCRIPTION
…llback

Firefox 138+ blocks Marionette chrome-scope commands unless the browser is started with -remote-allow-system-access, which the extension-page navigation fallback relies on.